### PR TITLE
release: v1.0.16 — pattern FP fixes + scanner parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ what got documented across releases.
 
 ## [Unreleased]
 
+## [1.0.16] - 2026-05-13
+
 ### Fixed
 
 - **`ii_financial_transaction_injection`** (score 75, input filter) — Tightened

--- a/aigis/__init__.py
+++ b/aigis/__init__.py
@@ -104,4 +104,4 @@ __all__ = [
     "SleeperDetector",
     "SleeperAlert",
 ]
-__version__ = "1.0.15"
+__version__ = "1.0.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyaigis"
-version = "1.0.15"
+version = "1.0.16"
 description = "Zero-dependency Python firewall for AI agents. 4-wall + L4-L7 defense built on 2025-2026 LLM-security papers (Mirror, StruQ, MI9, MemoryGraft, MSB, DataFilter, AdvJudge-Zero), 44 compliance templates across US/CN/JP/EU. Library, Docker sidecar, or CLI — drop-in for Claude Code, Cursor, FastAPI, LangChain."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` section from [aigis#19](https://github.com/killertcell428/aigis/pull/19) to the **v1.0.16** release.

- `ii_financial_transaction_injection` / `ii_concealment_from_user` / `afe_sensitive_file_read` — FP fixes preserve all original TPs while rejecting benign dunning text, refusal guardrails, and CVE write-ups respectively
- `pii_email_input` — ReDoS fix (~45× faster on pathological input)
- Scanner ↔ Guard pattern parity restored (209 patterns on both surfaces)

## Test plan

- [x] All 1359 tests pass (1332 baseline + 27 regression tests from #19)
- [x] CI green on the merged commit
- [x] Version bumped in `pyproject.toml` and `aigis/__init__.py`
- [x] CHANGELOG `[Unreleased]` promoted to `[1.0.16] - 2026-05-13`
- [ ] After merge, push tag `v1.0.16` to trigger the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)