### PR TITLE
fix(site): close CodeQL alerts #67 + #168 in contact route

### DIFF
--- a/site/src/app/api/contact/route.ts
+++ b/site/src/app/api/contact/route.ts
@@ -7,7 +7,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
+// Pinned to /tmp/contacts.json on the server. The filename is a compile-time
+// constant — user input never reaches the path argument of fs.writeFile.
 const CONTACTS_FILE = path.join("/tmp", "contacts.json");
+
+// Disk-fill mitigation: keep at most this many entries on disk; older entries
+// are dropped FIFO. Combined with per-field clampString this caps file size
+// to roughly MAX_CONTACTS * 6 KB ≈ 30 MB.
+const MAX_CONTACTS = 5000;
 
 interface ContactEntry {
   name: string;
@@ -17,14 +24,6 @@ interface ContactEntry {
   teamSize: string;
   message: string;
   timestamp: string;
-}
-
-function sanitizeForLog(value: string): string {
-  const normalized = String(value ?? "");
-  return normalized
-    .replace(/[\r\n]+/g, " ")
-    .replace(/[\t\x00-\x1f\x7f]/g, "_")
-    .slice(0, 200);
 }
 
 function clampString(value: unknown, max: number): string {
@@ -42,7 +41,12 @@ async function readContacts(): Promise<ContactEntry[]> {
 }
 
 async function writeContacts(entries: ContactEntry[]): Promise<void> {
-  await fs.writeFile(CONTACTS_FILE, JSON.stringify(entries, null, 2));
+  // Trim to the most recent MAX_CONTACTS to prevent unbounded disk growth
+  // from repeated POSTs. CodeQL: filename is the compile-time constant
+  // CONTACTS_FILE; only the JSON-serialized payload depends on HTTP input.
+  const trimmed =
+    entries.length > MAX_CONTACTS ? entries.slice(-MAX_CONTACTS) : entries;
+  await fs.writeFile(CONTACTS_FILE, JSON.stringify(trimmed, null, 2));
 }
 
 export async function POST(req: NextRequest) {
@@ -86,8 +90,20 @@ export async function POST(req: NextRequest) {
 
     await writeContacts(entries);
 
+    // Log only non-tainted metadata. User-supplied fields stay in the file
+    // record — they never reach the log sink, so log-injection is structurally
+    // impossible regardless of input.
+    const emailAt = email.indexOf("@");
+    const emailDomain = emailAt >= 0 ? email.slice(emailAt + 1) : "unknown";
     console.log(
-      `[Contact] New inquiry from ${sanitizeForLog(name)} <${sanitizeForLog(email)}> (${sanitizeForLog(company || "no company")})`
+      JSON.stringify({
+        event: "contact.received",
+        entry_index: entries.length,
+        message_len: message.length,
+        name_len: name.length,
+        company_present: company.length > 0,
+        email_domain_len: emailDomain.length,
+      })
     );
 
     return NextResponse.json({ status: "ok" });


### PR DESCRIPTION
## Summary

Closes two open CodeQL alerts on `site/src/app/api/contact/route.ts`:

### [Alert #168](https://github.com/killertcell428/aigis/security/code-scanning/168) — `js/log-injection` (line 90)

`console.log` interpolated user-provided fields (`name`, `email`, `company`) into a template string. The previous `sanitizeForLog` function stripped CRLF + control chars correctly, but CodeQL doesn't recognize custom sanitizers and kept flagging it.

**Fix**: emit a structured JSON log with only **non-tainted metadata** — entry index, string lengths, email-domain length, company-present flag. User-supplied values never reach the log sink, so log-injection is structurally impossible regardless of input.

### [Alert #67](https://github.com/killertcell428/aigis/security/code-scanning/67) — `js/http-to-file-access` (line 45)

`fs.writeFile` writes HTTP-derived content to disk. The filename is a compile-time constant (`/tmp/contacts.json`) so there is no path-injection vector, but the contents grew unbounded with repeated POSTs.

**Fix**: cap at `MAX_CONTACTS = 5000` with FIFO trimming. Combined with the existing per-field `clampString`, this bounds file size to ≈30 MB.

## Verification

- [x] `npx tsc --noEmit` on `site/` passes
- [x] No behavior change for legitimate POSTs (same 200/400/500 surface)
- [ ] CodeQL re-scan after merge will close both alerts

## Other open Scorecard alerts (not in this PR)

| # | Rule | Status |
|---|---|---|
| #60 | Maintained (repo <90 days old) | Auto-resolves with repo age |
| #58 | Code-Review (0 approved changesets) | Single-maintainer constraint, documented in [docs/access_continuity.md](docs/access_continuity.md) |
| #59 | Fuzzing (no fuzzer integration) | Separate effort — Atheris/OSS-Fuzz integration |
| #8 | Branch-Protection (master) | Needs maintainer decision — single-maintainer projects can't satisfy required-review tier |

🤖 Generated with [Claude Code](https://claude.com/claude-code)