### PR TITLE
fix(backend): pyjwt dep + feat(policy): Wall 1 risk_above escalation

### DIFF
--- a/aigis/policy.py
+++ b/aigis/policy.py
@@ -49,6 +49,9 @@ class PolicyRule:
       - memory_retention: max days to remember ("90d")
       - delegation_depth: max agent-to-agent hops (1-5)
       - department: required department scope ("sales", "engineering")
+      - risk_above: rule fires only when event.risk_score >= this (0-100)
+      - risk_level: rule fires only when event.risk_level is at or above this
+        ("low" < "medium" < "high" < "critical")
     """
 
     id: str
@@ -173,6 +176,18 @@ def _check_conditions(event: ActivityEvent, conditions: dict) -> bool:
         if event.memory_scope and required_dept not in event.memory_scope:
             return False  # Wrong department — condition not met
 
+    if "risk_above" in conditions:
+        threshold = int(conditions["risk_above"])
+        if event.risk_score < threshold:
+            return False  # Below risk threshold — rule does not apply
+
+    if "risk_level" in conditions:
+        order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+        required = order.get(str(conditions["risk_level"]).lower(), -1)
+        actual = order.get((event.risk_level or "low").lower(), 0)
+        if required < 0 or actual < required:
+            return False  # Below required risk level — rule does not apply
+
     return True  # All conditions satisfied
 
 
@@ -286,6 +301,28 @@ def _default_policy() -> Policy:
                 target="*",
                 decision="allow",
                 reason="LLM prompts are scanned by Aigis's detection engine",
+            ),
+            # === Risk-threshold catch-all (Wall 1 detector escalation) ===
+            # Fires last, only when nothing more specific matched. Lets
+            # Wall 1 / Wall 2 detection signals escalate to a hard block
+            # even if no name-based rule matched the action+target.
+            # NOTE: critical must come before high — rules are first-match,
+            # so a risk=95 event needs to hit deny before it hits review.
+            PolicyRule(
+                id="risk_threshold_critical",
+                action="*",
+                target="*",
+                decision="deny",
+                reason="Critical-risk content detected by Aigis scan engine",
+                conditions={"risk_above": 80},
+            ),
+            PolicyRule(
+                id="risk_threshold_medium",
+                action="*",
+                target="*",
+                decision="review",
+                reason="Suspicious content detected by Aigis scan engine",
+                conditions={"risk_above": 40},
             ),
         ],
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "psycopg2-binary>=2.9.9",
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
-    "python-jose[cryptography]>=3.3.0",
+    "pyjwt[crypto]>=2.8.0",
     "passlib[bcrypt]>=1.7.4",
     "bcrypt==4.0.1",
     "httpx>=0.27.0",

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -112,6 +112,86 @@ class TestPolicyEvaluation:
         assert decision2 == "allow"
 
 
+class TestRiskThresholdConditions:
+    """risk_above / risk_level conditions let Wall 1 detector signals
+    escalate to policy decisions even when no name-based rule matches.
+    """
+
+    def test_risk_above_blocks_critical(self):
+        # Critical risk on an otherwise-unmatched action should hit deny.
+        policy = _default_policy()
+        event = ActivityEvent(action="shell:exec", target="echo hello", risk_score=95)
+        decision, rule_id = evaluate(event, policy)
+        assert decision == "deny"
+        assert rule_id == "risk_threshold_critical"
+
+    def test_risk_above_reviews_medium(self):
+        # Medium-risk content (e.g. prompt-injection echo) should escalate
+        # to review without breaking the workflow.
+        policy = _default_policy()
+        event = ActivityEvent(action="shell:exec", target="echo 'Ignore previous'", risk_score=45)
+        decision, rule_id = evaluate(event, policy)
+        assert decision == "review"
+        assert rule_id == "risk_threshold_medium"
+
+    def test_risk_below_threshold_falls_through(self):
+        policy = _default_policy()
+        event = ActivityEvent(action="shell:exec", target="echo hi", risk_score=10)
+        decision, rule_id = evaluate(event, policy)
+        assert decision == "allow"
+        assert rule_id == "_default"
+
+    def test_named_rule_wins_over_risk_threshold(self):
+        # Name-based rules come first; risk fallback should not override them.
+        policy = _default_policy()
+        event = ActivityEvent(
+            action="shell:exec",
+            target="rm -rf / --no-preserve-root",
+            risk_score=100,
+        )
+        decision, rule_id = evaluate(event, policy)
+        assert decision == "deny"
+        assert rule_id == "dangerous_commands"
+
+    def test_risk_level_condition(self):
+        # A custom rule using risk_level instead of risk_above.
+        policy = Policy(
+            name="risk-level test",
+            rules=[
+                PolicyRule(
+                    id="block_high",
+                    action="*",
+                    target="*",
+                    decision="deny",
+                    conditions={"risk_level": "high"},
+                ),
+            ],
+            default_decision="allow",
+        )
+        event_high = ActivityEvent(action="shell:exec", target="foo", risk_level="high")
+        assert evaluate(event_high, policy)[0] == "deny"
+
+        event_low = ActivityEvent(action="shell:exec", target="foo", risk_level="low")
+        assert evaluate(event_low, policy)[0] == "allow"
+
+        event_crit = ActivityEvent(action="shell:exec", target="foo", risk_level="critical")
+        # critical > high, so the rule still fires.
+        assert evaluate(event_crit, policy)[0] == "deny"
+
+    def test_risk_above_persists_through_save_load(self):
+        # The simple YAML parser must round-trip integer conditions.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / "p.yaml")
+            policy = _default_policy()
+            save_policy(policy, path)
+            loaded = load_policy(path)
+
+        event = ActivityEvent(action="shell:exec", target="echo whatever", risk_score=95)
+        decision, rule_id = evaluate(event, loaded)
+        assert decision == "deny"
+        assert rule_id == "risk_threshold_critical"
+
+
 class TestPolicySaveLoad:
     def test_save_and_load(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Two fixes uncovered while end-to-end testing Aigis against Claude Code in `--dangerously-skip-permissions` (bypass) mode:

- **fix(backend)**: replace stale `python-jose` dep with `pyjwt` so the dashboard backend container actually starts. `backend/app/auth/jwt.py` always imported PyJWT but `pyproject.toml` listed python-jose, which wasn't imported anywhere in `backend/app/`. Result: `docker compose up -d` restart-loops the backend with `ModuleNotFoundError: No module named 'jwt'`.
- **feat(policy)**: let Wall 1 risk signals escalate to policy decisions via new `risk_above` / `risk_level` conditions, plus two default catch-all rules:
  - `risk_threshold_critical` (`risk_above: 80`) → **deny**
  - `risk_threshold_medium` (`risk_above: 40`) → **review** (logged with `event_type=policy_review` but does not exit-2 the hook)

  Before this change, a prompt-injection payload echoed via Bash (risk=45, matched `pi_system_prompt_leak`) fell through to `allow` because no name-based rule matched the action+target. Now it's surfaced to the dashboard / `aigis logs` as a review event without breaking benign workflows. The critical tier only fires at `risk≥80` where Aigis is highly confident.

  Name-based rules still come first (first-match wins), so `rm -rf /` etc. continue to deny via their specific rule IDs.

## Verification

- Real Claude Code in `--dangerously-skip-permissions` mode attempting to `Read ~/.ssh/id_rsa` → blocked by hook with `ssh_key_protection`; nothing leaked.
- Synthetic critical event (risk=100, multiple secrets in echo content) → blocked via new `risk_threshold_critical`.
- Backend rebuilt: `docker compose build backend && docker compose up -d` reaches `Up (healthy)`, `/health` returns 200, all 41 routes register.

## Test plan

- [x] `uv run pytest tests/test_policy.py -v` → 23/23 pass (17 existing + 6 new in `TestRiskThresholdConditions`: critical, medium, fallthrough, name-precedence, risk_level ordinal compare, YAML round-trip)
- [x] `uv run pytest --tb=no -q` → 1381/1381 pass, no regressions
- [x] `docker compose build backend && docker compose up -d` → backend Up (healthy), `/health` 200, 41 routes registered
- [x] PreToolUse hook E2E: 4/4 dangerous Claude Code tool calls blocked under bypass mode, all events landed in `.aigis/logs/`, `~/.aigis/global/`, and `~/.aigis/alerts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)