### PR TITLE
release: v1.1.0 — 21-patch rollup + hero CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,55 @@ what got documented across releases.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-15
+
+### Rollup
+
+v1.1.0 bundles every patch release from v1.0.1 through v1.0.21 into one
+minor version. The granular per-detector changelog for each cycle is
+preserved below in its original section. This rollup is a marketing /
+release-note artefact, not new code — running `pip install pyaigis==1.1.0`
+gives you exactly the same module set as `pip install pyaigis==1.0.21`.
+
+**Headline numbers (measured 2026-05-15 on `master` @ v1.1.0 candidate):**
+
+- **Tests:** 1,434 passed · 0 failed · 0 skipped (`uv run pytest --tb=no -q`)
+- **Benchmark:** 144/154 attacks detected (**93.5%** overall)
+  - **100% on the 11 paper-grounded attack categories** (prompt injection
+    EN/ZH, encoding-bypass, memory poisoning, second-order injection, MCP
+    poisoning, indirect injection, PII inputs EN/KO/ZH, data exfiltration,
+    autonomous exploit) — 76/76 attacks detected.
+  - 57.1–85.7% on alignment-frontier categories (sandbox escape,
+    self-privilege escalation, audit tampering, evaluation gaming, CoT
+    deception). These 10 misses are tracked on the L6 / L7 verifier
+    roadmap; the underlying research literature considers them partially
+    unsolved.
+- **False-positive rate:** 0/26 safe inputs flagged (**0.0%**)
+- **New detectors added since v1.0.0:** ≈ 60 across 14 auto-improvement
+  cycles touching memory poisoning, MCP/A2A multi-agent, indirect prompt
+  injection in retrieved content, data exfiltration channels, supply-chain
+  LLM attacks, encoding obfuscation, jailbreak/system-prompt extraction,
+  and compliance/regulation.
+
+**Operational hardening:**
+
+- OpenSSF Best Practices **Silver tier preparation** (v1.0.15) — DCO
+  enforcement, Sigstore keyless release attestation, assurance case,
+  access continuity inventory, tightened SECURITY.md SLA.
+- **`gpai_provider` policy template** (v1.0.14) — five EU AI Act Art. 53
+  / 55 detectors for General-Purpose AI providers.
+- **Scanner ↔ Guard pattern parity** (v1.0.16) — `aigis.scanner.scan()`
+  and `Guard(...)` now share all 209 patterns.
+- **`pii_email_input` regex perf fix** (v1.0.16) — ~45× faster on long
+  alphabetic inputs (~111 ms → ~2.5 ms on a 5 kB input with no `@`).
+- **False-positive tightening** on `ii_financial_transaction_injection`,
+  `ii_concealment_from_user`, `afe_sensitive_file_read` (v1.0.16) — fixes
+  documented FPs without losing any of the original true-positive
+  coverage.
+
+**For per-rule detail, blocked-example payloads, and ASR citations**, see
+the individual patch sections from v1.0.21 down to v1.0.1 below.
+
 ## [1.0.21] - 2026-05-14
 
 ### Hardened

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,6 +41,13 @@
   <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/images/demo_cli_ja.gif" alt="Aigis CLI Demo" width="700" />
 </p>
 
+<p align="center">
+  <sub>
+    AI エージェントを業務で運用するなら <strong>⭐ Star</strong> を ― 毎週、論文ベースの新規 detector を追加リリースしています。<br/>
+    リリース通知だけ欲しい場合は、ページ上部の <strong>Watch → Custom → Releases</strong> をクリック。
+  </sub>
+</p>
+
 ---
 
 <a id="quick-start"></a>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@
   <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/images/demo_cli_en.gif" alt="Aigis CLI Demo" width="700" />
 </p>
 
+<p align="center">
+  <sub>
+    <strong>⭐ Star this repo</strong> if you ship AI agents in production — we add new paper-grounded detectors on a weekly cycle.<br/>
+    Prefer email only on releases? Click <strong>Watch → Custom → Releases</strong> at the top of the page.
+  </sub>
+</p>
+
 ---
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyaigis"
-version = "1.0.21"
+version = "1.1.0"
 description = "Zero-dependency Python firewall for AI agents. 4-wall + L4-L7 defense built on 2025-2026 LLM-security papers (Mirror, StruQ, MI9, MemoryGraft, MSB, DataFilter, AdvJudge-Zero), 44 compliance templates across US/CN/JP/EU. Library, Docker sidecar, or CLI — drop-in for Claude Code, Cursor, FastAPI, LangChain."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
Promotes the work in master from **v1.0.21 → v1.1.0**. v1.1.0 is a marketing-anchor minor release that rolls up every patch from v1.0.1 through v1.0.21 (≈ 60 new detectors across 14 auto-improvement cycles since 2026-05-07). **No new code** beyond what's already in master at v1.0.21 — the version bump exists so visitors landing from the new Qiita article see a clean v1.1.0 tag rather than v1.0.21.

This PR also lands the hero CTA (`⭐ Star` + `Watch → Releases`) that was the original scope of the branch.

## What's in this PR
- `pyproject.toml`: `1.0.21` → `1.1.0`
- `CHANGELOG.md`: new `## [1.1.0] - 2026-05-15` section with the rollup narrative and the measured headline numbers
- `README.md` + `README.ja.md`: one-line sub-callout below the hero demo that frames the star ask + surfaces Watch → Custom → Releases

## Measured on this branch HEAD (2026-05-15)
- **Tests:** 1,434 passed · 0 failed · 0 skipped (`uv run pytest --tb=no -q`)
- **Benchmark:** 144/154 attacks detected (**93.5%** overall)
  - **100% on paper-grounded categories** (76/76 across prompt-injection, jailbreak, encoding, memory, MCP, indirect injection, PII, data exfiltration, autonomous exploit)
  - 57–86% on the 5 alignment-frontier categories (sandbox escape, self-privilege escalation, audit tampering, evaluation gaming, CoT deception) — the 10 misses sit entirely here
- **FP rate:** 0/26 safe inputs flagged (0.0%)
- **Note:** The 93.5% measurement supersedes the README hero's stale **98.9%** claim. The hero number correction lands in the v1.1.0 README rework PR (next-day scope), not here.

## Release plan (after merge)
1. Tag `v1.1.0` on master and push the tag
2. Release workflow auto-publishes the wheel to PyPI with Sigstore attestation
3. Overwrite the auto-generated GitHub Release body with the curated draft in `content/v1.1.0_release_body_draft.md` (twin-tier rate framing: "100% paper-grounded · 93.5% overall")
4. **Next-day:** separate PR for the v1.1.0 README rework — hero stat refresh, "What's new in v1.1.0" callout, OWASP Agentic Top 10 framing, comparison-table reframe

## Test plan
- [ ] CI green (ci.yml + codeql.yml + dco.yml)
- [ ] `pip install pyaigis==1.1.0` works after release workflow finishes
- [ ] GitHub Release v1.1.0 body shows the curated content, not just the auto-generated commit list
- [ ] Track Watchers count over the next week (currently 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)