### PR TITLE
ci+docs: reject orphan tags in release.yml; document merge-first-then-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,14 @@ jobs:
         with:
           fetch-depth: 0          # full history for changelog generation
 
+      - name: Reject orphan tags (must be reachable from master)
+        run: |
+          git fetch origin master
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from origin/master. Refusing to publish a release from an orphan commit. Merge the release commit to master first, then tag the master commit."
+            exit 1
+          fi
+
       - name: Resolve version
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,15 @@ http://localhost:8000 でプレビュー確認。
 
 **IMPORTANT: This section OVERRIDES the "one short user-visible sentence" instruction in the loop's Step 7 and Step 11. Write release notes at the level of detail specified here.**
 
+### Tag ordering — never tag before merging to master
+
+The release workflow (`.github/workflows/release.yml`) refuses to publish if the tagged commit is not reachable from `origin/master` (orphan-tag guard). Always:
+
+1. Land the `release: vX.Y.Z` commit on master via PR merge first.
+2. Only then create and push tag `vX.Y.Z` against the master commit.
+
+Pushing a tag from a feature branch HEAD will fail the release workflow and waste a version number. If you hit a "tag collision" error, **do not bump the version and retry from the same orphan commit** — that is the pattern that produced the v1.1.1 → v1.1.2 → v1.1.3 cascade of unreachable releases. Investigate why master doesn't have the release commit instead.
+
 ### CHANGELOG entries (Step 7)
 
 Each entry under `## [Unreleased]` must cover **every new `DetectionPattern` or detector** added in the cycle. For each one, write:

--- a/auto-improvement/README.md
+++ b/auto-improvement/README.md
@@ -27,3 +27,24 @@ aigis を 6 時間ごとに自動強化する保守ループの作業領域。
 - `pending/` を定期的に眺めて、採否を判断する
 - 大きな機能拡張・路線変更は人間が `pending/` を昇格 or 別ブランチで実装
 - リリースノートは `CHANGELOG.md` を読めば時系列で全変更が把握できる
+
+## リリース手順（必ずこの順序を守る）
+
+タグから feature ブランチを切らない。**master にマージされたコミットからのみタグを打つ**。
+`release.yml` は `merge-base --is-ancestor origin/master` の guard で orphan commit からのリリースを拒否する。
+
+1. feature ブランチで release コミット（`release: vX.Y.Z`）と `uv.lock` 更新を作成
+2. PR を開き、CI / レビューを通して **master にマージ**
+3. master の HEAD（マージ後のコミット）に対してタグを打つ
+   ```bash
+   git checkout master && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+4. タグ push が `release.yml` を起動 → PyPI 公開 → GitHub Release 作成
+
+### NG パターン（過去に v1.1.0〜v1.1.3 で発生）
+
+- feature ブランチの HEAD からタグを打って push する → orphan commit から公開されてしまう
+- PR が master にマージされずに残るため、CHANGELOG とソースツリーが一致しない
+- 次サイクルで「tag collision」を理由に version bump を再試行し、orphan tag を量産する


### PR DESCRIPTION
## Summary

- Add an orphan-tag guard at the start of `release.yml`'s `build` job that rejects tags whose commit is not reachable from `origin/master`
- Document the correct release order in `auto-improvement/README.md` (merge to master → tag the master commit → release fires)
- Add a tag-ordering note to the Auto-Improvement Loop section of `CLAUDE.md` so the remote agent stops creating orphan tags

## Why

The release workflow previously published any pushed tag matching `v*.*.*`, regardless of whether the tagged commit was on master. The auto-improvement loop has been tagging from its own feature-branch HEADs and pushing, which:

- Published v1.1.0–v1.1.3 to PyPI from orphan commits not on master
- Left the corresponding PRs (#50, #52) stuck open since master is `required_signatures: true` and these PRs cannot be merged after the release already shipped
- Caused a "tag collision" cascade where each cycle bumped the version (v1.1.1 → v1.1.2 → v1.1.3) instead of fixing the order

PR #52 was closed as part of this investigation. The guard prevents recurrence.

## Test plan

- [ ] Push a throwaway tag from a non-master branch and confirm the workflow's `build` job fails at the new guard step before any PyPI publish runs
- [ ] Push a tag from a commit on master and confirm the workflow proceeds normally

Tag-from-master is the supported path; tag-from-orphan is now refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)