### PR TITLE
loop: harden release path against tag-collision cascades (closes #56)

### DIFF
--- a/.github/workflows/orphan-tag-alarm.yml
+++ b/.github/workflows/orphan-tag-alarm.yml
@@ -1,0 +1,92 @@
+name: Orphan tag alarm
+
+# Nightly sweep that lists every release tag in the repo and flags any
+# that point to a commit not reachable from master. The release.yml
+# workflow's orphan-tag guard (added in #53) rejects orphan tags at
+# publish time, but a tag pushed before #53 landed — or pushed despite a
+# bug in the auto-improvement loop — can sit on the remote silently.
+#
+# This workflow opens a tracking issue (or updates an existing one) when
+# an orphan release tag is found, so it can't go unnoticed for long.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0  # need full history to walk ancestry
+          fetch-tags: true
+
+      - name: Scan release tags
+        id: scan
+        run: |
+          set -euo pipefail
+
+          ORPHANS=""
+          for tag in $(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V); do
+            sha=$(git rev-list -n 1 "$tag")
+            if ! git merge-base --is-ancestor "$sha" origin/master; then
+              ORPHANS="$ORPHANS\n- $tag → $sha"
+            fi
+          done
+
+          if [[ -z "$ORPHANS" ]]; then
+            echo "No orphan tags found."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Orphan tags detected:"
+          echo -e "$ORPHANS"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          # Use heredoc for multi-line output to GITHUB_OUTPUT
+          {
+            echo "list<<ORPHAN_LIST_EOF"
+            echo -e "$ORPHANS"
+            echo "ORPHAN_LIST_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.scan.outputs.found == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const list = `${{ steps.scan.outputs.list }}`;
+            const title = "[orphan-tag-alarm] Release tags not reachable from master";
+            const body = `The nightly orphan-tag scan found release tags pointing to commits that are **not reachable from \`master\`**:\n\n${list}\n\nThese tags can be published from the auto-improvement loop without ever landing the release commit on master, producing a release that doesn't match the source tree (see [Issue #56](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/56)).\n\nRecovery: see \`auto-improvement/scripts/release_preflight.sh\` and the v1.1.2 / v1.1.3 release advisory for the playbook.\n\n_This issue was auto-opened by \`.github/workflows/orphan-tag-alarm.yml\`. It will be reopened nightly until the orphan tags are resolved (either landed-to-master, deleted from the remote, or the workflow is silenced for a specific tag list)._`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: "orphan-tag",
+              state: "open",
+              per_page: 5,
+            });
+            if (existing.data.length > 0) {
+              const num = existing.data[0].number;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                body: `Nightly scan still finds orphan tags:\n\n${list}`,
+              });
+              core.info(`Updated existing issue #${num}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["orphan-tag", "release"],
+              });
+              core.info(`Opened issue #${created.data.number}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ _tmp_*
 
 # Local working notes
 _temp/
+
+# Auto-improvement loop scratch (never commit failed-push diffs)
+auto-improvement/_unpushed_*.patch
+auto-improvement/_failed_*.patch

--- a/auto-improvement/README.md
+++ b/auto-improvement/README.md
@@ -33,18 +33,34 @@ aigis を 6 時間ごとに自動強化する保守ループの作業領域。
 タグから feature ブランチを切らない。**master にマージされたコミットからのみタグを打つ**。
 `release.yml` は `merge-base --is-ancestor origin/master` の guard で orphan commit からのリリースを拒否する。
 
+### 必須: 毎回 `release_preflight.sh` を通すこと
+
+タグを push する直前に [`auto-improvement/scripts/release_preflight.sh`](scripts/release_preflight.sh) を実行する。失敗した場合は **何もせずに人間に escalate** する。bump して retry してはいけない（[Issue #56](https://github.com/killertcell428/aigis/issues/56) で documented した v1.1.2 / v1.1.3 cascade の原因）。
+
+```bash
+./auto-improvement/scripts/release_preflight.sh vX.Y.Z $(git rev-parse origin/master)
+# exit 0 → push 可
+# exit 2 → タグ衝突。bump 禁止、人間判断待ち
+# exit 3 → master 未到達 (orphan)。先に PR を merge
+# exit 4 → master tip ではない。新しい変更を取り込む
+```
+
+### 標準フロー
+
 1. feature ブランチで release コミット（`release: vX.Y.Z`）と `uv.lock` 更新を作成
 2. PR を開き、CI / レビューを通して **master にマージ**
-3. master の HEAD（マージ後のコミット）に対してタグを打つ
+3. master の HEAD（マージ後のコミット）に対して preflight → タグ
    ```bash
    git checkout master && git pull
+   ./auto-improvement/scripts/release_preflight.sh vX.Y.Z
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
 4. タグ push が `release.yml` を起動 → PyPI 公開 → GitHub Release 作成
 
-### NG パターン（過去に v1.1.0〜v1.1.3 で発生）
+### NG パターン（過去に v1.1.0〜v1.1.3 で発生 — Issue #56）
 
 - feature ブランチの HEAD からタグを打って push する → orphan commit から公開されてしまう
 - PR が master にマージされずに残るため、CHANGELOG とソースツリーが一致しない
 - 次サイクルで「tag collision」を理由に version bump を再試行し、orphan tag を量産する
+- 失敗時に `_unpushed_<timestamp>.patch` artifact をコミット → 履歴を汚染する（このパターンも禁止）

--- a/auto-improvement/scripts/release_preflight.sh
+++ b/auto-improvement/scripts/release_preflight.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# release_preflight.sh — gatekeeper the auto-improvement loop MUST call
+# before pushing a release tag. Implements the rules CLAUDE.md spells out
+# under "Tag ordering — never tag before merging to master" and addresses
+# the v1.1.2 / v1.1.3 orphan-release incident (Issue #56).
+#
+# Exit codes:
+#   0  — safe to push the tag
+#   2  — tag already exists on the remote (collision); abort, DO NOT bump
+#   3  — release commit is not reachable from origin/master (orphan); abort
+#   4  — local branch is not on the master tip (so the tag would point
+#         somewhere humans haven't reviewed); abort
+#   5  — usage error
+#
+# Usage:
+#   ./release_preflight.sh vX.Y.Z              # checks current HEAD
+#   ./release_preflight.sh vX.Y.Z <commit-sha> # checks the given sha
+#
+# The script never modifies the repo. It only reads. Run it from inside
+# a working checkout (it uses `git fetch origin --tags`).
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  cat >&2 <<USAGE
+release_preflight.sh — verify a tag is safe to push.
+
+Usage: $0 vX.Y.Z [commit-sha]
+USAGE
+  exit 5
+fi
+
+TAG="$1"
+SHA="${2:-HEAD}"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$ ]]; then
+  echo "[preflight] FAIL — tag $TAG does not match the release tag pattern vX.Y.Z" >&2
+  exit 5
+fi
+
+echo "[preflight] checking $TAG against $SHA"
+
+# 1. Refresh remote view of tags + master.
+git fetch --quiet origin --tags
+git fetch --quiet origin master
+
+RESOLVED_SHA=$(git rev-parse --verify "$SHA^{commit}" 2>/dev/null || true)
+if [[ -z "$RESOLVED_SHA" ]]; then
+  echo "[preflight] FAIL — could not resolve commit $SHA" >&2
+  exit 5
+fi
+
+# 2. Collision check — remote tag already exists?
+if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+  EXISTING=$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')
+  cat >&2 <<MSG
+[preflight] FAIL (exit 2) — tag $TAG already exists on the remote.
+            Existing tag points to: $EXISTING
+            Local release commit:   $RESOLVED_SHA
+
+DO NOT bump the version and retry. That is the pattern that produced
+the v1.1.1 → v1.1.2 → v1.1.3 orphan-release cascade (Issue #56).
+
+Recovery:
+  1. Stop the release run. Do not push any tag.
+  2. Inspect the existing tag:
+       git fetch --tags && git log $EXISTING --oneline -5
+  3. If the existing tag is itself orphaned (not reachable from master),
+     escalate to a human — the right fix is to either:
+       a) Land THIS release commit on master and re-tag with a fresh
+          version number that skips the burned numbers, or
+       b) Delete the orphan tag from the remote (only if no PyPI
+          release was published for it).
+  4. The auto-improvement loop must not retry until a human resolves
+     the collision.
+MSG
+  exit 2
+fi
+
+# 3. Orphan check — release commit must be reachable from origin/master.
+if ! git merge-base --is-ancestor "$RESOLVED_SHA" origin/master; then
+  cat >&2 <<MSG
+[preflight] FAIL (exit 3) — release commit $RESOLVED_SHA is NOT reachable
+            from origin/master. Tagging it would produce an orphan release
+            that the release.yml guard will reject — but the bad tag will
+            still pollute the remote tag namespace.
+
+Recovery:
+  1. Merge the release commit's PR into master via the normal review flow.
+  2. Re-run preflight against the master HEAD that contains the release.
+  3. Only then push the tag.
+MSG
+  exit 3
+fi
+
+# 4. Master-tip check — tagging behind master invites confusion (the
+#    release would not include subsequent fixes that landed first). The
+#    loop should always tag the master tip, not an old commit.
+MASTER_HEAD=$(git rev-parse origin/master)
+if [[ "$RESOLVED_SHA" != "$MASTER_HEAD" ]]; then
+  cat >&2 <<MSG
+[preflight] FAIL (exit 4) — release commit $RESOLVED_SHA is reachable from
+            origin/master but is NOT the master tip ($MASTER_HEAD).
+            Tagging this commit would skip changes that landed on master
+            between the release commit and now.
+
+Recovery:
+  1. Either rebase / cherry-pick the release commit onto master HEAD, or
+  2. Confirm with a human that you really want to tag the older commit
+     (e.g. cutting a patch release for a previous minor).
+MSG
+  exit 4
+fi
+
+echo "[preflight] OK — $TAG can be pushed against $RESOLVED_SHA"
+exit 0

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -1,0 +1,134 @@
+"""Smoke tests for auto-improvement/scripts/release_preflight.sh.
+
+Exercises the four failure modes (collision, orphan, behind-tip, OK) using a
+local bare repo as the "remote." Skips on platforms where bash isn't
+available (Windows runners without git-bash) so the script's logic still
+gets coverage on the Linux CI matrix.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "auto-improvement" / "scripts" / "release_preflight.sh"
+
+BASH = shutil.which("bash")
+pytestmark = pytest.mark.skipif(
+    BASH is None,
+    reason="bash not available on this runner — preflight is bash-only",
+)
+
+
+def _run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> int:
+    """Run a command and return its exit code, raising on stderr noise only
+    if the test asks for it via the returned object."""
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=full_env,
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return proc.returncode
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a bare 'remote' repo + a working clone with a single commit
+    on master. Returns (work_dir, bare_remote_path)."""
+    bare = tmp_path / "remote.git"
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(work)],
+        check=True,
+        capture_output=True,
+    )
+
+    # Identity needed for commits
+    _git(work, "config", "user.email", "test@example.com")
+    _git(work, "config", "user.name", "Test User")
+    _git(work, "remote", "add", "origin", str(bare))
+
+    (work / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-m", "seed")
+    _git(work, "push", "-u", "origin", "master")
+
+    return work, bare
+
+
+def test_ok_on_clean_master_tip(fixture_repo: tuple[Path, Path]) -> None:
+    work, _ = fixture_repo
+    assert BASH is not None
+    rc = _run([BASH, str(SCRIPT), "v1.0.0"], cwd=work)
+    assert rc == 0
+
+
+def test_fails_with_exit_2_on_tag_collision(fixture_repo: tuple[Path, Path]) -> None:
+    work, _ = fixture_repo
+    # Pre-create the tag on the remote (use -m so user gitconfig that
+    # forces annotated tags doesn't break the test fixture)
+    _git(work, "tag", "-a", "v1.0.0", "-m", "test")
+    _git(work, "push", "origin", "v1.0.0")
+    # Now try to preflight the same tag — should be rejected
+    assert BASH is not None
+    rc = _run([BASH, str(SCRIPT), "v1.0.0"], cwd=work)
+    assert rc == 2
+
+
+def test_fails_with_exit_3_on_orphan_commit(fixture_repo: tuple[Path, Path]) -> None:
+    work, _ = fixture_repo
+    # Create an orphan commit on a branch that never goes to master
+    _git(work, "checkout", "-b", "orphan-branch")
+    (work / "extra.md").write_text("orphan\n", encoding="utf-8")
+    _git(work, "add", "extra.md")
+    _git(work, "commit", "-m", "orphan commit")
+    assert BASH is not None
+    rc = _run([BASH, str(SCRIPT), "v1.0.0"], cwd=work)
+    assert rc == 3
+
+
+def test_fails_with_exit_4_when_behind_master_tip(
+    fixture_repo: tuple[Path, Path],
+) -> None:
+    work, _ = fixture_repo
+    # Record the seed commit, then advance master ahead of it
+    seed_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    (work / "second.md").write_text("second\n", encoding="utf-8")
+    _git(work, "add", "second.md")
+    _git(work, "commit", "-m", "second commit")
+    _git(work, "push", "origin", "master")
+    # Try to preflight the now-behind seed commit
+    assert BASH is not None
+    rc = _run([BASH, str(SCRIPT), "v1.0.0", seed_sha], cwd=work)
+    assert rc == 4
+
+
+def test_fails_with_exit_5_on_malformed_tag(fixture_repo: tuple[Path, Path]) -> None:
+    work, _ = fixture_repo
+    assert BASH is not None
+    rc = _run([BASH, str(SCRIPT), "not-a-version"], cwd=work)
+    assert rc == 5


### PR DESCRIPTION
## Summary

Closes [#56](https://github.com/killertcell428/aigis/issues/56). Stops the v1.1.2/v1.1.3 orphan-tag cascade from happening again by adding three guardrails to the in-repo half of the release path:

- **`auto-improvement/scripts/release_preflight.sh`** — gatekeeper the auto-improvement loop must call before pushing a release tag. Distinct exit codes for the four failure modes (`0` OK, `2` collision, `3` orphan, `4` behind master tip, `5` usage). Error messages explicitly tell the loop **not** to bump-and-retry on collision and cite Issue #56.

- **`.github/workflows/orphan-tag-alarm.yml`** — nightly cron that walks the release-tag namespace and opens (or comments on) a tracking issue when it finds a tag pointing at a commit not reachable from master. The release.yml guard from [#53](https://github.com/killertcell428/aigis/pull/53) catches orphans at publish time; this catches the silent ones that were already pushed before that guard existed.

- **`auto-improvement/README.md`** — strengthened release-flow docs: a mandatory preflight step, the exit-code table, an updated "NG patterns" section that names the `_unpushed_*.patch` artifact bug as an antipattern. `.gitignore` now excludes those scratch patches.

## Test plan

- [x] `uv run pytest tests/test_release_preflight.py -v` → 5 passed on Windows (bash via Git for Windows)
- [x] All four failure modes exercised against a local bare-repo fixture
- [x] OK path validated
- [ ] CI green on Linux runner
- [ ] orphan-tag-alarm.yml dry-run via `workflow_dispatch` after merge (will fire next 06:00 UTC otherwise)

## Why this PR doesn't fully close #56

The auto-improvement loop's actual code runs outside this repo on a maintenance agent. This PR ships the in-repo contract (the preflight script + docs) that the loop is now required to call. The loop's caller change is a one-line patch on that side: `./auto-improvement/scripts/release_preflight.sh vX.Y.Z || exit $?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)