### PR TITLE
ci: fix cosign sign-blob args for cosign v3 (use --bundle)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,13 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
+          # cosign v3 deprecated --output-signature / --output-certificate in
+          # favour of a single --bundle file containing both the signature and
+          # the Sigstore certificate. The v1.1.4 release run failed on the
+          # legacy flags ("create bundle file: open : no such file or directory").
           for artifact in dist/*; do
             cosign sign-blob --yes \
-              --output-signature "${artifact}.sig" \
-              --output-certificate "${artifact}.crt" \
+              --bundle "${artifact}.cosign.bundle" \
               "${artifact}"
           done
 


### PR DESCRIPTION
## Summary

The Release workflow's cosign signing step has been failing since cosign v3 deprecated the legacy `--output-signature` / `--output-certificate` flags. The v1.1.4 release run (run id 25998662303) failed at this step with:

\`\`\`
Error: signing dist/pyaigis-1.1.4-py3-none-any.whl:
       create bundle file: open : no such file or directory
\`\`\`

Replace the two-file flow with a single per-artifact `.cosign.bundle` file (the documented cosign v3 output). Verifiers now use `cosign verify-blob --bundle ...`.

## Why now

This is blocking the v1.1.4 release that was just merged via PR #58. After this PR lands, the v1.1.4 tag will be re-created against the new master HEAD so the fixed workflow runs against it.

## Test plan

- [ ] Lint & Type Check / Test 3.11 / Test 3.12 pass on this PR
- [ ] After merge, push v1.1.4 tag → Release workflow's cosign step succeeds → PyPI publish runs → GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)