### PR TITLE
ci: keep cosign bundles outside dist/ so PyPI publish does not reject them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,13 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
+          # cosign v3 deprecated --output-signature / --output-certificate in
+          # favour of a single --bundle file containing both the signature and
+          # the Sigstore certificate. The v1.1.4 release run failed on the
+          # legacy flags ("create bundle file: open : no such file or directory").
           for artifact in dist/*; do
             cosign sign-blob --yes \
-              --output-signature "${artifact}.sig" \
-              --output-certificate "${artifact}.crt" \
+              --bundle "${artifact}.cosign.bundle" \
               "${artifact}"
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,16 @@ jobs:
           COSIGN_EXPERIMENTAL: "1"
         run: |
           # cosign v3 deprecated --output-signature / --output-certificate in
-          # favour of a single --bundle file containing both the signature and
-          # the Sigstore certificate. The v1.1.4 release run failed on the
-          # legacy flags ("create bundle file: open : no such file or directory").
+          # favour of a single --bundle file. The bundles MUST live outside
+          # dist/ — pypa/gh-action-pypi-publish runs metadata verification on
+          # every file in dist/ and rejects unknown extensions (the v1.1.4
+          # first re-run failed with "InvalidDistribution: Unknown
+          # distribution format: pyaigis-1.1.4-py3-none-any.whl.cosign.bundle").
+          mkdir -p dist-signatures
           for artifact in dist/*; do
+            base=$(basename "${artifact}")
             cosign sign-blob --yes \
-              --bundle "${artifact}.cosign.bundle" \
+              --bundle "dist-signatures/${base}.cosign.bundle" \
               "${artifact}"
           done
 
@@ -91,6 +95,12 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
+      - name: Upload signatures
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-package-signatures
+          path: dist-signatures/
 
   # ── 2. Publish to PyPI ────────────────────────────────────────────────────
   publish-pypi:
@@ -180,13 +190,19 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
-          path: dist/
+          path: release-files/
+
+      - name: Download signatures
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-signatures
+          path: release-files/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "aigis ${{ github.ref_name }}"
           body: ${{ steps.changelog.outputs.body }}
-          files: dist/*
+          files: release-files/*
           make_latest: true
           generate_release_notes: true   # appends GitHub auto-notes after our body


### PR DESCRIPTION
## Summary

After #59 made cosign output a `.cosign.bundle` per artifact, the v1.1.4 release run failed at PyPI publish:

\`\`\`
Checking dist/pyaigis-1.1.4-py3-none-any.whl.cosign.bundle:
  ERROR  InvalidDistribution: Unknown distribution format
\`\`\`

`pypa/gh-action-pypi-publish` verifies every file in `dist/` against PyPI's accepted distribution formats and rejects anything else. The cosign bundle is not a PEP 740 attestation, so it can't live in `dist/`.

## Changes

- Sign step writes bundles to a separate `dist-signatures/` directory
- Add a second `upload-artifact` for `python-package-signatures`
- Release job downloads both artifacts into `release-files/` and attaches everything to the GitHub Release together

PyPI publish keeps reading from `dist/` unchanged — it now only sees wheels and sdists, as it expects.

## Test plan

- [ ] Required CI checks pass
- [ ] After merge, re-tag v1.1.4 against master HEAD and confirm the full Release pipeline succeeds (Build → Publish → GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)