### PR TITLE
docs(research): add 6-discipline foundation research for Aigis v2

### DIFF
--- a/docs/research/v2-foundations/01-immune-system.md
+++ b/docs/research/v2-foundations/01-immune-system.md
@@ -1,0 +1,121 @@
+# The Immune System as a Security Paradigm for Aigis
+
+## 1. Core immune system concepts and their AI-security mapping
+
+| Biology | Mechanism | AI-security analog |
+|---|---|---|
+| **Innate immunity** (PRRs detect PAMPs — e.g., TLR4 binding LPS) | Hard-coded receptors for conserved molecular signatures shared by broad pathogen classes. Fast, no learning. | Exactly what Aigis does today — regex/`DetectionPattern` matches on "ignore previous instructions", base64-wrapped payloads, MCP rug-pull descriptor diffs. PAMP = pattern. |
+| **Adaptive immunity** (B/T cell receptor diversity via V(D)J recombination, clonal selection, affinity maturation) | Random combinatorial receptor library → antigen binders are *selected and amplified*; somatic hypermutation produces higher-affinity variants. | A learning loop that generates detector "antibodies" against novel attacks and refines them over exposures. Aigis's `adversarial_loop.py` is a primitive of this. |
+| **Memory B/T cells** | Long-lived clones from past responses produce a faster, stronger secondary response. | A "memory pool" of past-attack embeddings/patterns, queried before invoking expensive checks. |
+| **Negative selection in thymus** (central tolerance) | T cells that bind *self* antigens too strongly are deleted during maturation. The mature repertoire by construction does not attack self. | Train detectors only on **known-good** agent traces, delete any detector that fires on them, keep the rest. Whatever survives flags non-self. |
+| **Peripheral tolerance / Treg cells** | Self-reactive cells that escape the thymus are suppressed in tissue. | Per-deployment whitelist / suppression layer that learns the *local* definition of normal for a given customer. |
+| **Danger model (Polly Matzinger, 1994)** | Immune system attacks things that emit *danger signals* (necrosis, HMGB1, ATP in wrong compartment), not things that are merely non-self. Explains why we tolerate gut flora and a fetus. | Don't flag based on "foreign-looking text" — flag based on *consequences*: tool calls that touch new capabilities, sudden privilege widening, exfiltration-shaped traffic, unexpected state writes. |
+| **MHC class I / II antigen presentation** | Every cell continuously displays fragments of its internal proteins on the surface; if the fragment is wrong (viral) or absent, the cell is killed. | Force every agent step to "present" its proof-of-state: structured trace of (prompt-hash, tool-args, memory-read-keys). A monitor inspects what was presented, not just inputs/outputs. |
+| **Cytokine cascade / inflammation** | Graded chemical response: local → systemic, with positive and negative regulators. | Replace binary allow/block with a *threat score* that decays over time, raises sensitivity of neighbors, and triggers escalation only past thresholds. |
+| **Autoimmune disease** (T1D, MS, lupus) | Tolerance breaks; immune system attacks self. | False positives — Aigis blocking a legitimate refactor request because it contains "delete file". The cost is loss of user trust, not just an annoyance. |
+| **Allergy / hypersensitivity (IgE, anaphylaxis)** | Overreaction to harmless antigens; the response itself is the damage. | Over-aggressive filtering that destroys task completion (e.g., a coding agent that refuses to read any `.env.example`). |
+
+## 2. Existing academic work — what was tried and why most of it stalled
+
+**Stephanie Forrest & Steven Hofmeyr — Computer immunology (UNM, 1996–2007).** Foundational work. `Intrusion detection using sequences of system calls` (J. Computer Security, 1998) showed short n-grams of syscalls from privileged UNIX processes give a clean self/non-self boundary. Worked well *on the narrow problem* — UNIX daemons in 1998 had very stable syscall distributions. **Why it didn't scale:** modern software is too dynamic; the "self" set is unbounded. ([Forrest's review, ACSAC 2008](https://www.cs.unm.edu/~forrest/publications/acsac08.pdf))
+
+**Negative Selection Algorithm (Forrest et al., 1994).** Generate random detectors, discard any that match self, keep the rest. **Critique:** Stibor, Timmis, and Eckert (2005–2006) showed the detector space grows exponentially in input dimensionality; on real network data NSA was *worse* than a one-class SVM. The 2023 ScienceDirect survey ([negative selection in anomaly detection — A survey](https://www.sciencedirect.com/science/article/abs/pii/S1574013723000242)) confirms the field has largely been outclassed by deep one-class methods, with niche revivals using r-chunk detectors.
+
+**Dasgupta's AIS textbook line (1999–2011).** Broadest framing of AIS as a soft-computing paradigm. Many algorithms (CLONALG, AIRS, aiNet) but mostly evaluated on UCI toy datasets. Field consensus by ~2015: most AIS algorithms are "GAs / k-NN / one-class SVMs with immunological vocabulary."
+
+**Dendritic Cell Algorithm — Greensmith, Aickelin, Cayzer (Nottingham, 2005–2010).** Real implementation of danger theory: combines "danger", "safe", and "PAMP" input signals into a context score. Strong on port-scan detection. **Limitations** (per Greensmith 2010 and the [2022 cursory-DCA review](https://www.mdpi.com/1999-4893/15/1/1)): signal categories must be *hand-engineered per domain*, online segmentation is awkward, and benchmarks rarely beat tuned ensemble baselines.
+
+**Danger theory in computer security — Aickelin & Cayzer (2002), Aickelin et al. (2003).** The most *philosophically* useful AIS contribution: stop trying to enumerate non-self; instead detect damage signals. Influenced modern XDR/EDR designs more than it's credited.
+
+**Recent (2024–2026) LLM/agent work that uses the immune analogy explicitly or implicitly:**
+
+- **[TraceAegis (arXiv:2510.11203, Oct 2025)](https://arxiv.org/abs/2510.11203)** — hierarchical behavioral anomaly detection on agent execution traces; F1 0.93–0.96 on healthcare/procurement benchmarks. This is essentially negative selection over agent trace n-grams.
+- **[Trajectory Guard (arXiv:2601.00516)](https://arxiv.org/pdf/2601.00516)** — lightweight sequence anomaly model for agentic AI, 17–27× faster than LLM-judge. Direct descendant of Hofmeyr/Forrest syscall-sequence IDS.
+- **[Open Challenges in Multi-Agent Security (arXiv:2505.02077)](https://arxiv.org/html/2505.02077v2)** — frames the threat surface (steganographic collusion, coordinated attacks). Useful adversary model.
+- **[Multi-Agent LLM Defense Pipeline (arXiv:2509.14285)](https://arxiv.org/html/2509.14285v4)** — Multiple cooperating LLM defenders; close to the "innate + adaptive" two-tier idea.
+- **[Hosseini et al., AIS for Industrial IDS, Wiley 2025](https://onlinelibrary.wiley.com/doi/full/10.1155/je/8408209)** — PRISMA review confirming AIS is still active in OT/ICS but trailing on LLM-era threats.
+
+**Net assessment of the field:** AIS contributed two enduring ideas — (a) *danger > non-self*, and (b) *populations of cheap heterogeneous detectors beat one monolithic classifier* — and a lot of overfit benchmarks. Modern deep one-class models eat its lunch on pure accuracy; its remaining value is *architectural inspiration* and *interpretability* (each detector has a meaning).
+
+## 3. Concrete architectural proposals for Aigis v2
+
+### A. Innate layer (keep what works — clarify the framing)
+**Component:** Today's `aigis/patterns.py` (~803 lines, 100+ `DetectionPattern`s). Relabel internally as the *innate* layer; expose a `pattern.pamp_class` field (e.g., `instruction_override`, `exfil_shape`, `capability_widening`). This is purely conceptual but enables every other layer to reason about *what kind of danger* fired.
+**Detects:** Conserved attack signatures — public jailbreaks, known MCP rug-pull diffs, well-known data-exfil URLs.
+**Attack model:** Unsophisticated / copy-pasted attacks.
+**FP risk:** Already measured at 0/26 in v1.1.0 benchmark.
+
+### B. Negative-selection trace detector (NEW — highest priority)
+**Component:** `aigis/immune/negative_selection.py`. Embed agent execution traces (sequences of `tool_name + arg_schema_hash + memory_keys_touched`) using a small sentence-embedding model. During a "tolerance phase" per deployment, learn the convex hull of normal traces. At runtime, flag traces whose nearest-neighbor cosine distance > τ.
+**Detects:** Semantic bypasses of the pattern layer — attacks worded in novel ways but producing *behaviorally* anomalous tool-call sequences (e.g., `read_file → http_post` where normal traces always have `read_file → summarize`).
+**Attack model:** Attacker reads `patterns.py` on GitHub and rewrites the payload until no regex fires. Negative selection doesn't care about wording, only about behavior.
+**FP risk:** Medium-high. Mitigations: (i) per-customer tolerance training, (ii) require trace anomaly *plus* a danger signal from layer C before blocking, (iii) ship in "shadow / log-only" mode for N runs before enforcement.
+**Prior art:** TraceAegis is essentially this; replicate it as an offline-trainable component shipped with Aigis.
+
+### C. Danger-signal layer (Matzinger-style) (NEW)
+**Component:** `aigis/immune/danger.py`. A short list of *consequence* detectors that fire regardless of input wording:
+- Capability widening: tool A called with arg set never seen before for this session.
+- Memory delta: write to a memory key that's read by a future session of a *different* user.
+- Egress shape: outbound payload contains > N bytes of base64 / high-entropy strings.
+- Authority escalation: a sub-agent obtains a token the parent didn't have.
+**Detects:** Indirect prompt injection where the *prompt* looks innocuous (page summary) but the resulting actions are damaging.
+**Attack model:** Indirect injection via retrieved content / poisoned tools.
+**FP risk:** Lower than B because danger signals are tied to side-effects, which are inherently rare.
+**Wiring:** Danger signal scores feed into a graded threat score (layer F).
+
+### D. Adaptive memory ("B-cell pool") (NEW — formalize what `adversarial_loop.py` already drafts)
+**Component:** `aigis/immune/memory_pool.py`. When *any* layer (B/C/E) flags a novel attack with high confidence:
+1. Hash + embed the offending input + the tool-call trace.
+2. Generate K mutated variants (LLM-driven paraphrase, encoding swaps, splitting, language flip).
+3. Add (original + variants) to a persistent memory index.
+4. On future requests, do a sub-millisecond ANN lookup against the memory pool before invoking heavier checks. A hit = immediate block with the original rule_id as evidence.
+
+### E. MHC-style trace attestation (NEW — structural, not statistical)
+**Component:** `aigis/immune/attestation.py`. Wrap each agent step so it must emit a signed structured `Presentation`:
+```
+{step_id, prompt_hash, system_prompt_hash, tools_offered_hash,
+ chosen_tool, args_schema_hash, memory_read_keys, parent_step_id}
+```
+A monitor (running out-of-band) verifies invariants: tools_offered_hash matches the registered MCP servers; memory_read_keys are within the agent's declared capability; parent_step_id forms a valid DAG. Anything that fails attestation is killed *before* execution.
+**Detects:** MCP rug-pull at runtime (server changes tool schema mid-session → `tools_offered_hash` changes → kill), capability escalation, prompt-template tampering.
+**Attack model:** Supply-chain attacks against MCP servers.
+**FP risk:** Near zero — these are structural checks, not statistical.
+
+### F. Cytokine layer / graded response (NEW)
+**Component:** `aigis/immune/cytokines.py`. Replace boolean `block_or_allow` with a continuous `inflammation_score ∈ [0, 1]` per session that:
+- Increments on any layer firing (weighted by danger class).
+- Decays exponentially with time and successful clean steps.
+- Above threshold T1: require user confirmation on next tool call.
+- Above T2: switch the agent's model to a stricter system prompt ("immune-activated mode").
+- Above T3: terminate session, emit audit event.
+
+### G. Peripheral tolerance / per-customer whitelist (NEW)
+**Component:** A first-class `tolerance_profile.yaml` loaded per deployment. Negative selection (layer B) trains against it; danger thresholds (layer C) read it. Without this, B will produce unacceptable FP rates on diverse customer workloads — the same reason the thymus alone is insufficient and you need Tregs.
+
+## 4. Honest critique — where the metaphor breaks
+
+1. **Biology has co-evolution over 500M years; AIS designers don't.**
+2. **"Self" is well-defined in a body, undefined in software.** A cell's "self" is its MHC-presented peptides — physically grounded. An LLM agent's "self" is whatever you decide normal looks like.
+3. **AIS overfit on toy benchmarks.** When evaluated on modern data, AIS rarely beats a tuned isolation forest. Don't assume immune framing gives you accuracy gains; it gives you *architecture* gains.
+4. **Autoimmunity is a real, expensive failure mode.** FPs in immunology look like lupus or T1D. Negative selection without strong tolerance training is *guaranteed* to produce this.
+5. **Inflammation has off-switches that we have to design.** Biology has IL-10, Tregs, glucocorticoids. The "cytokine score" idea above needs explicit dampeners.
+6. **The danger model is not actually a clean theory in immunology either.** Matzinger's danger model is still debated.
+7. **You cannot ship sterile.** Aigis is open-source; attackers will read the immune layers too. Pattern + negative-selection + danger + memory raises *cost* of bypass, it doesn't eliminate it.
+
+## 5. Recommended reading (3–5, highest signal first)
+
+1. **Forrest, S. & Beauchemin, C. (2007). *Computer Immunology*.** Immunological Reviews 216:176–197. ([PDF](https://www.cs.unm.edu/~forrest/publications/computer-immunology))
+2. **Hofmeyr, S., Forrest, S., & Somayaji, A. (1998). *Intrusion detection using sequences of system calls*.** J. Computer Security 6(3). ([SAGE](https://journals.sagepub.com/doi/10.3233/JCS-980109))
+3. **Aickelin, U. & Cayzer, S. (2002). *The Danger Theory and Its Application to Artificial Immune Systems*.** ICARIS.
+4. **Liu, J. et al. (2025). *TraceAegis*.** [arXiv:2510.11203](https://arxiv.org/abs/2510.11203)
+5. **Greensmith, J., Aickelin, U., & Cayzer, S. (2010). *Detecting Danger: The Dendritic Cell Algorithm*.** [arXiv:1006.5008](https://arxiv.org/pdf/1006.5008)
+
+Optional 6th: **Stibor, T., Timmis, J., & Eckert, C. (2005).** Strongest critique of NSA.
+
+## Top 3 to prototype (ranked effort/impact)
+
+| Rank | Prototype | Effort | Impact |
+|---|---|---|---|
+| 1 | **MHC-style trace attestation (layer E)** in `aigis/immune/attestation.py`. Pure structural checks, near-zero FP. | ~1 week | High |
+| 2 | **Cytokine / graded response (layer F)** in `aigis/immune/cytokines.py`. Refactor binary block path into a score with decay and three thresholds. | ~1 week | High |
+| 3 | **Negative-selection trace detector (layer B) + B-cell memory pool (layer D)** — ship together. Train tolerance per customer; require a danger signal to *block* (otherwise log-only). | 3–4 weeks | Highest ceiling |

--- a/docs/research/v2-foundations/02-mechanism-design.md
+++ b/docs/research/v2-foundations/02-mechanism-design.md
@@ -1,0 +1,137 @@
+# Mechanism Design as a Security Paradigm for Aigis v2
+
+## 0. The reframing
+
+Detection (Aigis v1) is a **classifier game**: defender picks features, attacker picks inputs, attacker moves last and wins at the limit. No amount of pattern engineering changes the structure — it's the same loss curve antivirus has been on for 30 years.
+
+Mechanism design changes the game itself. Instead of asking *"can I tell this input is malicious?"*, you ask *"can I arrange the rules so that the malicious move is dominated by an honest one, regardless of how clever the attacker is?"* The asymmetry you want is the one blockchains discovered: cheap to verify, expensive to attack, and **the attacker pays even if they're never caught**.
+
+For Aigis specifically, this is what survives the day someone reads `aigis/patterns/*.py` and crafts a semantic bypass: a v2 layer that doesn't depend on pattern secrecy.
+
+## 1. Core concepts and how they map to LLM/agent security
+
+| Concept | One-line definition | Aigis-relevant translation |
+|---|---|---|
+| **Incentive compatibility** | Truth-telling is a (weakly) dominant strategy | Tool calls that misrepresent their effects cost the caller more than calls that don't |
+| **Strategy-proof** | Player can't gain by deviating from the mechanism's preferred input | Agent gains nothing from prompt-injecting another agent because the orchestrator routes by *capability*, not by *intent claims* |
+| **VCG** | Each agent's payment = externality they impose on others | Tool calls priced by counterfactual impact on other principals' utility (rarely literal $, more often: rate-limit budget, escalation thresholds) |
+| **Slashing / bonded stake** | Validators post collateral; misbehavior → forfeit | Every MCP tool call carries a slashable bond from caller (or its operator) |
+| **Skin in the game** (Taleb) | Decision-makers bear downside | Whoever writes a system prompt also signs liability for its outputs |
+| **Reputation** | History → trust score → access | Provenance-bound agent identity (AIP) gates which tools an agent can call |
+| **Commitment schemes** | Hash now, reveal later → can't lie about what you said | Pre-execution commit to (plan, tool set, args schema); post-hoc deviations are blockable |
+| **Adversarial training / GAN** | Equilibrium between attacker and defender models | Red-team agents continuously probe; new bypasses become new patterns automatically |
+| **Moving target defense** | Rotate the attack surface faster than recon | Rotate prompt salts, tool ABI nonces, capability token formats |
+| **Honeytokens** | Decoys whose only purpose is to fire alarms | Inject canaries into prompts/contexts; egress hit = injection succeeded |
+| **Cost asymmetry** | Verifier << attacker cost | PoW / signed attestation per tool call; trivial for one user, ruinous for fuzzing |
+
+## 2. Existing academic & industrial work (what shipped, what didn't)
+
+**Stackelberg Security Games (Tambe et al.)** — *Did ship.* GUARDS (TSA, 400+ airports), PROTECT (USCG ports), ARMOR (LAX), IRIS (Federal Air Marshals). Defender commits first (publicly!), attacker best-responds; defender randomizes optimally. The lesson for Aigis: **publishing your rules can be safe if randomization makes the attacker's best response no better than uniform guessing**. See [Tambe lab overview](https://teamcore.seas.harvard.edu/ai-and-game-theory-public-safety-and-security/) and the [Milind chapter PDF](https://personal.ntu.edu.sg/boan/papers/Milindchapter.pdf).
+
+**CaMeL (DeepMind, 2025)** — *Shipping in research stacks.* Capability-based dual-LLM with a Python interpreter enforcing data-flow policy. Blocks 67% of AgentDojo attacks **without retraining**. This is the closest existing instantiation of "mechanism > detection." [arxiv:2503.18813](https://arxiv.org/abs/2503.18813).
+
+**AIP — Agent Identity Protocol (2026)** — *Draft IETF, running implementation.* Invocation-Bound Capability Tokens (IBCTs) fuse identity, attenuated authorization, and provenance into an append-only chain. Reputation derived from action receipts; 0.22 ms HTTP overhead. [arxiv:2603.24775](https://arxiv.org/abs/2603.24775), [IETF draft](https://datatracker.ietf.org/doc/draft-prakash-aip/). **This is the missing infrastructure layer Aigis can plug into.**
+
+**Kill-Chain Canaries (2026)** — Cryptographic canary tokens tracked across 950 agent runs, 5 frontier models, 4 kill-chain stages. Conclusion: *"prompt injection is not a model-capability problem, it is a pipeline-architecture problem."* [arxiv:2603.28013](https://arxiv.org/html/2603.28013v2).
+
+**Design Patterns for Securing LLM Agents** — Codifies action-constraining patterns; the closest thing to a "mechanism design textbook" for agent security. [arxiv:2506.08837](https://arxiv.org/html/2506.08837v3).
+
+**Moving Target Defense for LLMs** — "Jailbreaker in Jail" (ACM MTD '23) and ADA (Kubernetes ephemeral rotation, [arxiv:2505.23805](https://arxiv.org/html/2505.23805v1)). Mostly infrastructure-level; prompt-level MTD is nascent.
+
+**Crypto-economic primitives transferable to Aigis** — *Proof of Diligence* ([arxiv:2402.07241](https://arxiv.org/pdf/2402.07241)) and *Economic Censorship Games in Fraud Proofs* ([arxiv:2502.20334](https://arxiv.org/abs/2502.20334)) formalize how to bound rational misbehavior with stake + challenge windows.
+
+**What hasn't shipped:** explicit VCG-style pricing for tool calls, formal prompt-injection economics modeling attacker cost. This is a research gap Aigis could occupy.
+
+## 3. Concrete architectural proposals for Aigis v2
+
+### 3.1 Capability tokens with slashable bond (AIP-compatible)
+Every MCP tool call carries a header:
+
+```
+X-Aigis-Cap: JWS{ caller_did, tool_id, args_hash, ttl, bond_ref, parent_cap? }
+```
+
+`bond_ref` is a Merkle leaf into an operator-held bond pool. Aigis ships an `aigis.bond` module that:
+1. Issues caps (orchestrator side).
+2. Verifies caps (server side) before pattern checks run.
+3. Emits a `SlashReceipt` when post-hoc audit (`aigis.audit.replay`) finds a cap was used to launder an injection.
+
+Why this works: even if attacker bypasses the pattern, the cap chain names who signed off. Reputation degrades; bond burns. Closed-loop economic feedback that pattern matching alone cannot give.
+
+### 3.2 Honeytoken canaries — `aigis.canary`
+```python
+canary = aigis.canary.mint(scope="system_prompt", ttl=3600)
+system_prompt = canary.wrap(system_prompt)
+# later, in any egress:
+aigis.canary.scan(outbound_payload)  # raises CanaryLeaked → IR-13 SEV1
+```
+Each canary is a HMAC over (session_id, slot, nonce) — unguessable, unforgeable, and **a single hit is ground truth that exfil succeeded**. Pairs naturally with the Kill-Chain Canaries paper's empirical framework.
+
+### 3.3 Commit-reveal plans for agents
+Before any tool sequence runs, the agent must POST a `PlanCommit`:
+```
+commit = H(plan_dsl || nonce)
+```
+Tool calls during execution must each carry `(plan_idx, opening)` proving the call was in the committed plan. Mid-execution prompt injection that tries to introduce *new* tool calls fails the opening check. This directly defeats the dominant prompt-injection pattern of "hijack mid-flight."
+
+### 3.4 Moving target prompt salting
+Rotate per-session a `prompt_salt` woven into your system prompt as a required prefix on every meta-instruction. Patterns the attacker scraped from GitHub stop matching; the salt becomes a per-session shared secret between Aigis and the model. Cheap (single 16-byte token), and turns the "open source detector" problem into the "open source detector with per-session keying" problem.
+
+### 3.5 Cost-asymmetric verification (Hashcash for tool calls)
+Optional `X-Aigis-PoW: <nonce>` such that `H(call || nonce)` has `k` leading zeros. `k` is **dynamic per agent reputation**: 0 for AIP-verified high-rep agents, 18 for unknown clients. A human typing 1 req/sec doesn't notice. A fuzzing rig doing 10⁴ req/sec hits a wall.
+
+### 3.6 Optimistic verification with fraud proofs
+Tool calls execute immediately with provisional commit. A `challenge_window` (e.g., 60s) lets any auditor (could be `aigis.audit` running async) submit a `FraudProof` = (call, replay trace, violated invariant). Successful proof → slash + roll back. Borrowed wholesale from Optimistic Rollups.
+
+### 3.7 Honeypot tools
+Register decoy MCP tools (`hr_export_all_employees`, `admin_disable_filters`) that **no legitimate plan ever calls**. Any call to them is an injection. Zero false positives by construction.
+
+## 4. The hard question — who is the designer?
+
+Mechanism design assumes (a) a designer with authority, (b) identifiable players, (c) enforceable payments. In the open agent ecosystem all three are partial:
+
+- **(a) Authority** holds *within* a deployment (an enterprise running its own orchestrator IS the designer for its agents) but not *across* deployments.
+- **(b) Identity** is the bottleneck. Pre-AIP, MCP has no agent identity. Post-AIP, you can do real mechanism design. **Aigis should hard-couple to AIP-style identity** because every other mechanism above depends on it.
+- **(c) Payment** doesn't have to be money. Slashable resources include: rate-limit budget, capability scope, reputation score, allow-list membership.
+
+**Where the analogy holds:** within an enterprise deployment, within a federation of mutually-attested agents, within a marketplace with a curator.
+**Where it breaks:** between strangers on the open internet with no shared root of trust. Here you fall back to detection (Aigis v1) plus *only* sandbox-grade isolation.
+
+## 5. Crypto-economics: what transfers, what doesn't
+
+**Transfers:**
+- **Slashing of bonded stake** → cap tokens with operator bond.
+- **Optimistic execution + fraud proofs** → execute tool, async audit, rollback on violation.
+- **Fishermen / watchtowers** → third-party auditors running Aigis in replay mode against logs.
+- **Challenge periods** → "high-stakes tool calls have a 30s soft commit before externalizing."
+
+**Doesn't transfer cleanly:**
+- **Global consensus** — agent ecosystems don't need or want a global ledger.
+- **Token-based MEV / staking economics** — financial token markets are absent.
+- **Long unbonding periods** — agent interactions are seconds, not weeks.
+
+## 6. Honest critique — the dark side
+
+**Sybil attacks.** Cheap identities destroy reputation systems. Mitigation: rep gated on attested compute (AIP's hardware-bound key), or on staked external resources.
+
+**Collusion.** Two agents owned by the same attacker can fake interactions to build reputation (wash trading). Mitigation: require attestations from *disjoint* principals weighted by their *own* independently-built reputation.
+
+**Misaligned principals.** The orchestrator's operator may *want* the agent to do shady things. Only meaningful for *cross-principal* trust.
+
+**Wash trading / fake reputation.** Markets for high-rep agent identities will appear. Mitigation: bind reputation to **behavior under audit**, not raw call counts; sample-based replay verification.
+
+**Mechanism gaming itself.** Honeytokens get stripped; PoW gets GPU-accelerated; cap tokens get stolen. None defeat the *paradigm* — they each force the attacker to a higher cost tier.
+
+## 7. Recommended reading (ranked by signal)
+
+1. **Debenedetti et al., "Defeating Prompt Injections by Design" (CaMeL), 2025** — [arxiv:2503.18813](https://arxiv.org/abs/2503.18813). Read first.
+2. **Prakash, "AIP: Agent Identity Protocol," 2026** — [arxiv:2603.24775](https://arxiv.org/abs/2603.24775) + [IETF draft](https://datatracker.ietf.org/doc/draft-prakash-aip/).
+3. **Beurer-Kellner et al., "Design Patterns for Securing LLM Agents," 2025** — [arxiv:2506.08837](https://arxiv.org/html/2506.08837v3).
+4. **Tambe (ed.), *Security and Game Theory*, Cambridge, 2011.**
+5. **Sheng et al., "Proof of Diligence," 2024** — [arxiv:2402.07241](https://arxiv.org/pdf/2402.07241).
+
+## Top 3 concrete things to prototype (effort/impact ranked)
+
+1. **`aigis.canary` — honeytoken module.** *Effort: 1–2 days. Impact: high.* Pure Python, no protocol changes, zero false positives by construction.
+2. **Commit-reveal plan enforcement (`aigis.plan`).** *Effort: 1–2 weeks. Impact: very high.* Forces agents to declare tool sequences up front; mid-flight injection becomes structurally impossible.
+3. **AIP-aligned capability tokens with slashable bond (`aigis.cap`).** *Effort: 4–8 weeks; needs ecosystem buy-in. Impact: paradigm-shifting if it lands.*

--- a/docs/research/v2-foundations/03-os-systems-security.md
+++ b/docs/research/v2-foundations/03-os-systems-security.md
@@ -1,0 +1,169 @@
+# Systems-Security Primitives for Aigis v2: Capabilities, Sandboxing, and OS-Level Isolation
+
+## 0. The thesis in one paragraph
+
+Aigis v1 is a **detector** — it answers "is this input/output malicious?" using ~100 deterministic patterns. The structural weakness is obvious: in open source, an attacker can read the rules. The systems-security tradition spent fifty years on the dual question: **"given that the input is malicious, what authority does it actually convey?"** That is the question capability systems, sandboxing, and MAC frameworks answer. For Aigis v2, the right move is not to replace detection but to **layer it under capability-mediated execution**, so a bypass of a detector is bounded by what the agent's capability set can actually express. Detection is probabilistic; capability is structural. They compose multiplicatively.
+
+## 1. Core concepts
+
+### 1.1 Capability-based security
+
+A **capability** is an unforgeable, transferable reference that names an object *and* the right to act on it. There is no separate ACL lookup, no "ambient authority", and no name-to-object resolution that an attacker can spoof. Possession of the capability *is* the permission.
+
+- **seL4** — microkernel with machine-checked functional-correctness, integrity, and confidentiality proofs down to binary code. ([seL4 Verification](https://sel4.systems/Verification/))
+- **CHERI / ARM Morello / CHERIoT** — hardware capabilities: pointers become 128-bit fat references with bounds and permission bits enforced by the ISA. ([CHERI-seL4](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/cheri-sel4.html), [VeriCHERI arxiv](https://arxiv.org/pdf/2407.18679))
+- **Fuchsia** — Google's microkernel OS. Every Zircon syscall takes a handle (a capability).
+- **KeyKOS / EROS / Genode** — the lineage. Genode is the practical descendant.
+- **E language / Mark Miller's work** — the object-capability ("ocap") model formalized.
+
+### 1.2 Sandboxing & SFI (Software Fault Isolation)
+
+- **WebAssembly (Wasmtime, Wasmer, WASI Preview 2)** — deny-by-default capability runtime. A `.wasm` module has no `open`, no `socket`, no clock unless the host passes a capability. **The single most relevant primitive for Aigis v2.**
+- **gVisor** — userspace re-implementation of ~70-80% of the Linux syscall surface in Go. ~10-30% I/O overhead.
+- **Firecracker** — KVM microVMs, ~125ms boot, ~5 MiB memory overhead.
+- **Native Client (NaCl)** — instructive even though deprecated.
+- **seccomp-bpf** — syscall allowlist as BPF program.
+- **Landlock** — unprivileged filesystem and (since 6.7) network sandboxing.
+
+### 1.3 MAC / DAC
+
+- **SELinux / AppArmor / BSD MAC** — labels-and-policy. Useful when you need a *third party* to override what the program would otherwise be allowed to do.
+
+### 1.4 Privilege separation & POLA
+
+- **OpenSSH privsep** — the canonical example. A small "monitor" process holds privileges; an unprivileged "slave" parses untrusted network input.
+- **POLA (Principle Of Least Authority)** — the object-capability community's version of POLP.
+
+### 1.5 TCB minimization
+
+seL4's TCB is ~10 kLOC of C. Linux's is ~25 MLOC. For an LLM agent, the agent's *prompt and model weights are part of the TCB* if they decide which tool to call — unless capabilities make that decision unforgeable.
+
+## 2. Existing AI-security applications (2024-2026)
+
+- **Wassette (Microsoft, Aug 2025)** — runs MCP tools as Wasm Components with a deny-by-default, per-tool capability grant. ([Microsoft Open Source Blog](https://opensource.microsoft.com/blog/2025/08/06/introducing-wassette-webassembly-based-tools-for-ai-agents/), [InfoWorld](https://www.infoworld.com/article/4039243/wassette-a-bridge-between-wasm-and-mcp/))
+- **wasmcp** — polyglot SDK for composing MCP servers from Wasm components ([github.com/wasmcp/wasmcp](https://github.com/wasmcp/wasmcp)).
+- **Hyper MCP** — Rust MCP host loading tools as sandboxed WASM plugins.
+- **MCP-SandboxScan (arxiv 2601.01241)** — WASM-based secure execution + runtime analysis for MCP tools.
+- **Sandlock (Multikernel, Mar 2026)** — per-tool-call fork + Landlock + seccomp-bpf, no containers ([multikernel.io](https://multikernel.io/2026/03/25/sandlock-mcp-per-tool-sandboxing/)).
+- **Google Agent Sandbox (KubeCon NA 2025)** — gVisor-backed sandbox pods.
+- **Tenuo / IBCTs (arxiv 2603.24775, "AIP: Agent Identity Protocol")** — cryptographic capability tokens. ~0.05 ms verification.
+- **Cerbos for MCP** — policy-engine layer over MCP permission scoping.
+- **OWASP MCP Top 10 (2025)** — first formal MCP risk taxonomy.
+
+Vector that has *not* shipped publicly yet: **CHERI for AI workloads**. Greenfield.
+
+## 3. Concrete proposals for Aigis v2
+
+### 3.1 Object-capability MCP tool registry (effort: M, impact: HIGH)
+
+Replace MCP's tool-name-as-string addressing with an unforgeable capability handle. The Aigis broker becomes the *only* component that can mint handles.
+
+**Attack prevented (structurally):** Prompt-injected tool calls to tools the agent was never granted. If the model emits `call_tool("delete_database", ...)` but holds no `delete_database` capability, the broker drops the call before any string-matching detector runs. No bypass via clever obfuscation, base64, language switching, etc.
+
+**API sketch:**
+```python
+caps = aigis.mint_capabilities(
+    agent_id="researcher-007",
+    grants=[
+        Cap("filesystem.read", scope="/home/user/papers/**"),
+        Cap("http.fetch", scope="arxiv.org"),
+    ],
+    ttl=timedelta(hours=1),
+)
+ctx = aigis.AgentContext(caps=caps)
+result = ctx.invoke(cap_handle, args)
+```
+
+Handle = signed `(agent_id, tool_id, scope, parent_handle?, exp, nonce)` — essentially the IBCT design from arxiv 2603.24775.
+
+### 3.2 WASI sandboxing for MCP tools (effort: M-L, impact: HIGH)
+
+`aigis-wasi-shim`: a runner that loads each MCP server as a Wasm Component. Host passes only the WASI capabilities declared in `aigis.toml` per tool.
+
+**Attack prevented:** A compromised MCP tool cannot exfiltrate `~/.ssh/id_rsa` because the WASI host did not pass a preopened dir containing it. No filesystem grant = no `open` syscall.
+
+```toml
+[tools.read_doc]
+wasm = "oci://ghcr.io/acme/read_doc:1.2"
+wasi.fs.preopen = { "/data" = "ro" }
+wasi.net.allow  = []
+wasi.env        = []
+```
+
+Wassette already does most of this; Aigis adds the **detector layer behind the sandbox** so the broker can also pattern-scan inputs/outputs as defense-in-depth.
+
+### 3.3 Per-call Landlock+seccomp confinement for non-Wasm tools (effort: S, impact: MEDIUM)
+
+For native Python/Node MCP servers we can't easily compile to Wasm, wrap each invocation in `fork() → Landlock(rulesets) → seccomp(allowlist) → exec`. ~3 ms overhead per call.
+
+**Attack prevented:** Token-theft via reading env vars / dotfiles; sub-process exec (`bash -c`); raw socket; ptrace. seccomp blocks `execve`, `mount`, `ptrace`, `process_vm_*`, `unshare`.
+
+### 3.4 Capability attenuation & chained delegation (effort: M, impact: HIGH for multi-agent)
+
+Adopt IBCT/Biscuit-style append-only token chains. When agent A delegates to sub-agent B, A's broker mints a *strictly weaker* token. Cryptographically enforced: B cannot widen its own scope.
+
+**Attack prevented:** Confused-deputy in multi-agent / A2A systems.
+
+### 3.5 Aigis broker as a privsep monitor (effort: S, impact: STRUCTURAL)
+
+Split Aigis into two processes: a tiny **broker** (capability table, policy, signing key — <2 kLOC) and a **scanner** (the detector engine — large, exposed to attacker-controlled text). Scanner runs unprivileged, drops syscalls, talks to broker over a unix socket with a typed protocol.
+
+**Attack prevented:** An RCE in a YAML/regex parser inside the scanner cannot mint capabilities.
+
+### 3.6 SELinux/AppArmor profile shipped with Aigis (effort: XS, impact: LOW-MEDIUM)
+
+Bundled MAC policy: `aigis_t` domain that can read its config, listen on the broker socket, and nothing else.
+
+### 3.7 Forward path: CHERI/CHERIoT for embedded MCP (effort: L, research-grade)
+
+Port Aigis broker to CHERIoT-RTOS for edge/IoT MCP deployments. Tool handles become hardware capabilities.
+
+## 4. How this composes with v1 detection
+
+| Layer | Question answered | Failure mode if alone |
+|------|----------|----------|
+| **v1 detectors** (regex + heuristic) | "Is this input/output suspicious?" | Bypassable by attackers who read the rules |
+| **Capability broker** (3.1, 3.4) | "Does the agent even *have* the right to do this?" | Allows benign-looking but unsafe tool composition |
+| **WASI / Landlock sandbox** (3.2, 3.3) | "If the call is made, what can the callee touch?" | Doesn't see the prompt; can't reason about intent |
+| **MAC / privsep** (3.5, 3.6) | "If everything else fails, what does the OS still refuse?" | Coarse-grained |
+
+Aigis v1 is a *probabilistic upper bound* on attacks. Capabilities are a *structural upper bound* on damage.
+
+The Aigis v2 thesis: **detectors are eyes, capabilities are hands. Tie the hands and the eyes can be wrong without catastrophe.**
+
+## 5. Honest critique
+
+**Why haven't capabilities won in 40 years?**
+- *Developer ergonomics.* ACLs map onto "users and groups" which humans understand.
+- *Migration cost.* You cannot bolt capabilities onto POSIX without breaking software that assumes `open("/etc/passwd")` works.
+- *Tooling.* No `strace` equivalent for capability flows until recently.
+- *Network effects.* For AI agents this is *changing now* because the runtime is new.
+
+**WASM limitations.**
+- Missing syscalls: WASI Preview 2 still lacks robust threads, full POSIX sockets, `fork`.
+- Cold start: ~5-50ms per module load.
+- Numerics: 10-30% slower for SIMD-heavy code.
+- Python-on-Wasm (componentize-py) works but isn't seamless.
+
+**Confused deputy / capability leakage.**
+- Capabilities solve the deputy problem *only if* you actually attenuate on delegation.
+- Side channels: a capability cannot prevent the agent from *describing* sensitive data in its outputs.
+- Revocation: capability tokens with long TTL = stolen-token risk.
+
+## 6. Recommended reading (ranked by signal)
+
+1. **Mark Miller, *Robust Composition: Towards a Unified Approach to Access Control and Concurrency Control*** (PhD thesis, 2006).
+2. **Klein et al., *seL4: Formal Verification of an OS-Kernel Microkernel*** (CACM, 2010 + updates at [sel4.systems](https://sel4.systems/Verification/)).
+3. **Watson et al., *CHERI: A Hybrid Capability-System Architecture***.
+4. **The AIP / IBCT paper, arxiv [2603.24775](https://arxiv.org/pdf/2603.24775).** Most actionable artifact for Aigis.
+5. **Wassette docs + source ([blog](https://opensource.microsoft.com/blog/2025/08/06/introducing-wassette-webassembly-based-tools-for-ai-agents/))** and **Sandlock writeup ([multikernel.io](https://multikernel.io/2026/03/25/sandlock-mcp-per-tool-sandboxing/))** — current-art reference implementations.
+
+Honorable mention: Norm Hardy's 1988 "Confused Deputy" memo.
+
+## Top 3 to prototype (effort × impact)
+
+1. **Capability-handle MCP broker (§3.1)** — *highest impact, medium effort.* Eliminates string-matched tool dispatch entirely. Ship as `aigis.broker` with IBCT-style signed handles.
+2. **Per-call Landlock + seccomp sandbox (§3.3)** — *cheapest big win.* No new dependency, no Wasm compilation, ~3 ms overhead.
+3. **WASI shim for tools that can compile to Wasm (§3.2)** — *highest structural ceiling.* Slot in alongside (1) and (2).
+
+**Strategic point:** Aigis v1 competes in the crowded "detect bad prompts" space. Aigis v2, if it ships the broker + sandbox combo, becomes the *only* open-source MCP layer that combines (a) deterministic pattern detection, (b) unforgeable capability dispatch, and (c) OS-level isolation under a single policy file.

--- a/docs/research/v2-foundations/04-web-security.md
+++ b/docs/research/v2-foundations/04-web-security.md
@@ -1,0 +1,147 @@
+# Web Security as the Template for AI Agent Security
+
+## 1. The web security primitives, summarized
+
+The browser is the world's most-attacked sandbox. It evolved a layered defense stack against a threat model that is essentially identical to the one LLM agents face: **untrusted content (instructions encoded as data) mixed with trusted context (the user's session, secrets, capabilities) inside an executor that can act on both.**
+
+| Primitive | One-line essence | Direct AI analog |
+|---|---|---|
+| **Same-Origin Policy (SOP)** | Origin = (scheme, host, port). Code from one origin cannot read another. | Every prompt fragment gets an origin tag; instructions from `tool_output://` cannot mutate the goal set by `user://`. |
+| **Content Security Policy (CSP)** | Declarative whitelist of script sources, eval, inline. | Per-session declarative tool/network/eval policy. |
+| **Trusted Types** | DOM sinks demand typed objects, not strings; eliminates DOM-XSS by typing. | Tool args constructed from LLM output must pass a typed sanitizer; never raw `${llm_output}` interpolation into shell/SQL/code. |
+| **Subresource Integrity (SRI)** | `integrity="sha384-..."` pins external script hash. | RAG/web-fetched chunks carry hashes; mid-session drift = abort. |
+| **CORS** | Cross-origin reads are opt-in via response header. | Cross-origin reads in the prompt graph (tool A reading tool B's output) need explicit policy opt-in. |
+| **Cookie attributes (HttpOnly/Secure/SameSite)** | Defense-in-depth layering of a single object. | Secrets in the agent's context are tagged: `HttpOnly` (never echoable to LLM output), `SameSite` (no cross-tool leakage). |
+| **iframe `sandbox`** | Strip capabilities from embedded content. | Sub-agent / quarantined LLM run with stripped tool list — this is Willison's [Dual LLM](https://simonwillison.net/2023/Apr/25/dual-llm-pattern/). |
+| **Permissions Policy** | Per-origin gating of geolocation, mic, camera. | Per-tool gating of network, filesystem, secrets, state-changing actions. |
+| **Site Isolation** | One renderer process per site; Spectre containment. | One sandbox/container per untrusted-content session; blast-radius limit. |
+
+**The killer insight:** after SOP was invented in 1996, every subsequent web defense was a different answer to the question "what is the *origin* of this content?" **Provenance is the load-bearing concept.**
+
+## 2. The Dual-LLM lineage — already converging on the web model
+
+Simon Willison's [dual LLM pattern](https://simonwillison.net/2023/Apr/25/dual-llm-pattern/) explicitly cited the privileged/unprivileged split.
+
+- **2023 — Dual LLM (Willison).** P-LLM has tools; Q-LLM reads untrusted content and emits only opaque variable references back to P-LLM.
+- **2025 March — CaMeL** ([arxiv:2503.18813](https://arxiv.org/abs/2503.18813), DeepMind). Realizes dual-LLM as a capability system: P-LLM emits a typed Python-subset program; values from Q-LLM are wrapped in `Value` objects carrying **capability tags (origin + reader set + integrity)**. The interpreter is a capability monitor. **Functionally SOP + CORS + Trusted Types compiled to a small VM.**
+- **2025 May — Operationalizing CaMeL** ([arxiv:2505.22852](https://arxiv.org/abs/2505.22852)). Adds prompt screening, output auditing, tiered risk, and a formally verified IL.
+- **2025 June — Lethal Trifecta** ([Willison](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/)). Private data + untrusted content + external comms = compromise.
+- **2025 Oct — Meta's "Agents Rule of Two"** ([ai.meta.com](https://ai.meta.com/blog/practical-ai-agent-security/)). Pick at most 2 of {untrusted input, sensitive data, state change} per session.
+- **2026 March — CaMeLs Can Use Computers Too** ([arxiv:2601.09923](https://arxiv.org/abs/2601.09923)). Extends CaMeL to computer-use agents via single-shot planning.
+- **2026 May — Microsoft's "When prompts become shells"** ([MSRC](https://www.microsoft.com/en-us/security/blog/2026/05/07/prompts-become-shells-rce-vulnerabilities-ai-agent-frameworks/)) documents RCE chains via prompt → tool args → shell — precisely the class Trusted Types was invented to kill.
+
+Also relevant: [DRIFT](https://arxiv.org/pdf/2506.12104), [Polymorphic Prompt Assembling](https://arxiv.org/pdf/2506.05739) (analogous to ASLR for prompts), the [reversec design-patterns post](https://labs.reversec.com/posts/2025/08/design-patterns-to-secure-llm-agents-in-action) (`SourcedString` = tainted strings with carried provenance, a direct port of Perl taint mode 1989).
+
+## 3. The killer insight: provenance is the right primitive
+
+**Claim: AI agent security will rhyme with web security, and the load-bearing concept is *origin*.**
+
+1. Every published agent vulnerability of 2024–2026 (EchoLeak / [CVE-2025-32711](https://arxiv.org/abs/2509.10540), Salesforce Agentforce, Copilot Cowork, MCP rug-pulls) has the same structure: **content from origin X was treated as if it came from origin Y.** EchoLeak: an email's body was promoted to "user instruction" because both lived in the same context window. This is XSS, retold.
+2. Every promising defense — Dual LLM, CaMeL, Rule of Two, tainted strings, plan-before-data — is implicitly an origin discipline.
+3. Filtering ("did this look like an attack?") will keep failing for the same reason web XSS filters failed: it's a semantic question. Origin-checking is a *structural* question.
+
+Where the analogy weakens: in the browser, code and data are syntactically separable (parsed by different grammars). In an LLM, "code" and "data" are the same token stream — the model decides which is which. So **origin tagging cannot live inside the prompt; it must live in the orchestrator that *assembles* the prompt** and in the *interpreter* that *executes* tool calls. Aigis sits exactly there.
+
+## 4. Concrete proposals for Aigis v2
+
+### 4.1 `aigis.origin` — Origin model for prompt content (SOP)
+
+Every byte fed to an LLM is wrapped in `Tagged(content, origin, integrity)`. Origin URI scheme:
+
+```
+system://aigis/v1                      # the policy itself
+developer://app-name/role              # baked-in role prompt
+user://session-id                      # the human in the loop
+tool_output://mcp/github/issue/42      # MCP server replies
+retrieved://web/sha256-...             # RAG chunks (hash-pinned)
+agent_memory://session-id/turn-7       # prior turns
+```
+
+```python
+from aigis.origin import Tagged, Origin, assemble
+
+ctx = [
+    Tagged(system_prompt, Origin("system://aigis/v1")),
+    Tagged(user_msg, Origin(f"user://{sid}")),
+    Tagged(tool_resp, Origin(f"tool_output://mcp/jira/{ticket}")),
+]
+prompt = assemble(ctx, policy="strict")     # raises if origins disallowed
+```
+
+**Attack stopped.** EchoLeak class: forbid `tool_output://email/*` from carrying weight ≥ `user://` for goal-setting.
+**Effort.** ~2 weeks. Pure wrapper around prompt assembly; no model changes.
+
+### 4.2 `aigis.csp` — CSP for tool calls
+
+```yaml
+default: deny
+allow_tools:        [read_file, grep, list_dir]
+allow_network:      none
+allow_eval:         none
+allow_state_change: [draft_email]
+origin_trust:
+  user://*:         instructions=high, data=high
+  tool_output://*:  instructions=none,  data=medium
+  retrieved://*:    instructions=none,  data=low
+report_uri: https://aigis.example.com/violations
+```
+
+`instructions=none` means: text from this origin is allowed as evidence but never as a goal/imperative.
+
+**Attack stopped.** Indirect injection: a poisoned web page tells the agent to email customer data. The fetched page's origin is `retrieved://`, which has `instructions=none`.
+**Effort.** ~3–4 weeks.
+
+### 4.3 `aigis.tt` — Trusted Types for LLM outputs (kills tool-arg injection)
+
+Any tool whose argument grammar is dangerous (`shell.exec`, `sql.query`, `http.request`, `eval`) declares **typed sinks**. The LLM cannot pass a raw string; it must pass a `ShellCommand`, `SqlQuery`, `Url`, etc., which can only be constructed by an Aigis-provided sanitizer.
+
+```python
+@tool(arg_types={"cmd": ShellCommand})
+def run(cmd: ShellCommand) -> str: ...
+
+# LLM emits {"cmd": "rm -rf /"} -> Aigis parses through shlex,
+# checks against an argv allowlist, rejects.
+```
+
+**Attack stopped.** [Microsoft's "prompts become shells" RCE class](https://www.microsoft.com/en-us/security/blog/2026/05/07/prompts-become-shells-rce-vulnerabilities-ai-agent-frameworks/). String interpolation of `${llm_output}` into a shell is structurally impossible.
+**Effort.** ~1–2 weeks per dangerous tool family.
+
+### 4.4 `aigis.sri` — Hash-pinned retrieval
+
+Every retrieved chunk (RAG, web, MCP tool reply that's deterministic) is hashed on first read and the hash is recorded in the session's manifest. On every subsequent read, the hash is re-checked. Drift → abort or quarantine.
+
+**Attack stopped.** RAG cache poisoning, MCP rug-pull (server changes tool description between approval and call), TOCTOU between two reads of the same doc.
+**Effort.** ~1 week.
+
+### 4.5 `aigis.iso` — Process-level site isolation for sub-agents
+
+When a Q-LLM is spawned to read tainted content, it runs in a separate process with: (i) no network egress, (ii) no shared memory with the P-LLM, (iii) a restricted output channel that returns only **opaque handles** back to the P-LLM.
+
+**Attack stopped.** Side channels and exfil through clever P-LLM prompting of its own Q-LLM. Direct port of Chrome's [Site Isolation](https://www.chromium.org/Home/chromium-security/site-isolation/).
+**Effort.** ~3 weeks.
+
+## 5. Honest critique
+
+**Web security took 25+ years and still ships XSS.** Mitre tracks XSS at #2 in CWE Top 25 for 2024. If the AI field traces the same curve, expect prompt injection to be *common but mostly survivable* by 2035, only for deployments that adopted structural primitives early.
+
+**Browsers had a forcing function; MCP doesn't.** WHATWG/W3C are why CSP exists everywhere. MCP has no equivalent — the [July 2026 RC spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) is moving but vendor adherence is uneven. Implication: **don't wait for a standard; ship a *gateway* that enforces unilaterally.**
+
+**CSP deployment friction is real and CSP-for-LLM will be worse.** Most production CSPs are `unsafe-inline` because devs gave up. Mitigations: (a) ship a *report-only* mode first; (b) ship `aigis-csp-evaluator`; (c) make default templates per MCP server.
+
+**The asymmetry that *helps* AI security.** Unlike browsers, LLM agents have a single chokepoint per session (the orchestrator). The window to bake origin tagging into MCP and AgentSDKs is *now*, before it ossifies.
+
+## 6. Recommended reading
+
+1. **Willison, "The lethal trifecta for AI agents"** ([simonwillison.net 2025-06-16](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/))
+2. **Debenedetti et al., "Defeating Prompt Injections by Design" (CaMeL)** ([arxiv:2503.18813](https://arxiv.org/abs/2503.18813))
+3. **Meta AI, "Agents Rule of Two"** ([ai.meta.com 2025-10-31](https://ai.meta.com/blog/practical-ai-agent-security/))
+4. **Reversec, "Design Patterns to Secure LLM Agents In Action"** ([labs.reversec.com 2025-08](https://labs.reversec.com/posts/2025/08/design-patterns-to-secure-llm-agents-in-action))
+5. **W3C, "Trusted Types"** ([w3c.github.io/trusted-types](https://w3c.github.io/trusted-types/dist/spec/)) and **Google, "Site Isolation"** ([chromium.org](https://www.chromium.org/Home/chromium-security/site-isolation/))
+
+## Top 3 to prototype (ranked)
+
+1. **`aigis.origin`** — origin tags on every prompt fragment. **Why first:** every other defense depends on this primitive. Smallest PR. This is Aigis's SOP.
+2. **`aigis.tt`** — Trusted Types for dangerous tool args. **Why second:** highest ratio of *attack-class eliminated* per *line of code*. Survives open-source disclosure fully.
+3. **`aigis.csp`** — declarative per-session policy with `report-only` mode. **Why third:** public-facing artifact deployers will edit; ship after `origin` and `tt` so the schema is informed.
+
+Skip-for-now: `aigis.sri` (small but mostly relevant once RAG is in scope), `aigis.iso` (high value but needs the others as scaffolding).

--- a/docs/research/v2-foundations/05-cryptography-tee.md
+++ b/docs/research/v2-foundations/05-cryptography-tee.md
@@ -1,0 +1,135 @@
+# Cryptographic and formal-methods primitives for AI/LLM agent security
+
+The thesis: detection alone has a ceiling, but the cryptographic primitives that would actually shift that ceiling are at very different states of maturity. Some are deployable in 2026 with modest effort; others are research papers with two-orders-of-magnitude overhead.
+
+## 1. Trusted Execution Environments
+
+**CPU TEEs.** Intel SGX is end-of-life on client CPUs and surviving in a reduced form on Xeon scalable; Intel TDX is the successor and provides VM-level isolation rather than enclave-level. AMD SEV-SNP is the production-deployed equivalent. ARM provides TrustZone (mobile, mature) and CCA (Confidential Compute Architecture, server, shipping in Neoverse V3/Cobalt). RISC-V Keystone is research. Apple's Secure Enclave is a co-processor for key custody.
+
+**Cloud-vendor wrappers.** AWS Nitro Enclaves are the most pragmatic TEE in production: VM-isolated, no SGX-style side-channel surface, simple attestation document signed by AWS root. Azure Confidential VMs use SEV-SNP or TDX. GCP Confidential Space adds an attested workload identity. None of these protect against the cloud vendor itself.
+
+**GPU TEEs — the actual unblock for LLMs.** NVIDIA Confidential Computing is supported on H100, H200, B200 (Blackwell), and GB200. The on-die Confidential Compute Engine AES-256-GCM-encrypts every HBM write; Blackwell adds encrypted NVLink and PCIe 5.0. Throughput penalty measured at 4–8% on H100 inference, diminishing with batch size ([arxiv:2509.18886](https://www.arxiv.org/pdf/2509.18886)).
+
+**What this actually protects, for LLMs.**
+- Model weights at rest and in HBM: yes.
+- System prompts and KV-cache in HBM: yes.
+- A malicious tenant on the same node: yes.
+- Side channels (cache, power, EM): mostly no — see §8.
+- The cloud provider with hardware access: no, by design.
+
+**Apple Private Cloud Compute** is the most articulated commercial threat model. Devices wrap request keys only to public keys of nodes whose attested measurements match a build in the public transparency log; Apple commits to publishing every production PCC image for inspection. Closest thing to "cryptographic deployment of an LLM" as of 2026.
+
+Anthropic and OpenAI have made limited public statements: Anthropic operates on AWS and references Nitro Enclaves in some compliance contexts; OpenAI's "ZDR" is policy, not cryptography. Neither has shipped attested confidential inference equivalent to PCC.
+
+## 2. Zero-Knowledge Proofs
+
+**Primitives.** zkSNARKs (Groth16, PLONK, HyperPlonk) give short proofs and small verifier cost at the price of a trusted setup and expensive prover. zkSTARKs (post-quantum, transparent setup) trade larger proofs for no setup. Folding schemes (Nova, HyperNova) and lookup arguments are the 2024–2026 plumbing.
+
+**State of zkML, 2025–2026.** EZKL (open-source, Halo2-based) is the lingua franca for proving small ONNX models. Modulus Labs and Giza target on-chain inference up to ~18M parameters. Lagrange's DeepProve-1 (2025) is the first system to prove a full GPT-2 (124M) forward pass; reported 50–150× faster than EZKL. zkPyTorch (March 2025) compiles PyTorch graphs directly to ZK circuits and proves VGG-16 (138M) in ~2.2s. zkLLM and NANOZK ([arxiv:2603.18046](https://arxiv.org/pdf/2603.18046)) explore layerwise proofs.
+
+**What can be proven.** A specific model `M` with specific weights `W` produced output `y` from input `x`. The verifier learns only `(commit(W), commit(x), y)` and a proof. Exactly the primitive needed for "verifiable inference."
+
+**What cannot be proven.** That the model is *safe*, *aligned*, or *not jailbroken*. ZK proves a computation matches a circuit; it does not encode semantic properties. Also: GPT-2 is ~3 orders of magnitude smaller than current frontier models.
+
+## 3. MPC and Homomorphic Encryption
+
+**MPC for inference.** 2-party and 3-party protocols (CrypTen, MP-SPDZ, Cheetah, Iron, Bumblebee) have been demonstrated for BERT-scale models with latencies of seconds to tens of seconds per inference. State of the art for transformer MPC sits around 30–100× slowdown vs plaintext for sub-billion-param models.
+
+**FHE for inference.** ZAMA's Concrete-ML v1.7 ships an LLM example that runs GPT-2 token generation in ~11s on H100 GPU. A LLAMA-1B FHE prototype exchanges ~18 MB per token. For frontier-scale models, FHE is still firmly research.
+
+**Verdict.** MPC for narrow, small models in regulated settings (healthcare, finance) is feasible today. FHE for LLM-scale is not. **For Aigis, neither MPC nor FHE is the right v2 primitive** — they protect *inputs* from the model provider, which is orthogonal to Aigis's threat model.
+
+## 4. Cryptographic provenance and attestation
+
+**Mature primitives, deployable now.**
+- **Sigstore / cosign** for keyless signing of artifacts (containers, binaries, models). NVIDIA NGC began signing models with Sigstore in July 2025; Hugging Face has experimental support.
+- **SLSA** (Supply-chain Levels for Software Artifacts).
+- **In-toto / ITE-6** is the envelope format that carries provenance claims.
+- **TPM/DICE** provide hardware-rooted device identity and measured boot.
+- **C2PA** signs media manifests. Manifest format is content-agnostic and could carry signed system prompts as assertions.
+
+**This is the area where Aigis can ship something cryptographic in 2026 with minimal R&D.**
+
+## 5. Formal verification
+
+**What works at LLM scale.** Essentially nothing on the weights themselves. Formal methods cannot verify semantic safety properties of a neural network beyond toy robustness bounds.
+
+**What works around LLMs.**
+- seL4-style verified kernels for sandboxing.
+- Verus, F*, Lean, Coq for verifying the *guardrail code itself* — Aigis's detection pipeline, policy engine, signature-verification path. Realistic and high-leverage.
+- IFC type systems for taint-tracking from untrusted inputs to dangerous tool calls. Closest thing to a "formal model of prompt injection" — see the CaMeL design pattern ([arxiv:2506.08837](https://arxiv.org/pdf/2506.08837)).
+
+## 6. Concrete proposals for Aigis v2
+
+### Proposal A — Signed prompt and tool-descriptor provenance (Sigstore + in-toto)
+
+Every system prompt, tool description, and MCP server manifest is signed by its author using Sigstore (keyless OIDC) and wrapped in an in-toto attestation. Aigis ships a verifier that:
+
+1. Refuses to load an unsigned tool descriptor (configurable).
+2. Records the signing identity in the audit log alongside every tool call.
+3. Pins expected signers per project via an `aigis.lock`-style file.
+
+**Attack model defeated.** MCP rug-pull (vendor silently swaps `read_file`'s description). Modified descriptor fails signature verification.
+**Feasibility today.** High. 2–4 engineer-weeks for MVP. **Ship in v2.**
+
+### Proposal B — TEE-enclaved system prompt + capability tokens (Nitro Enclaves)
+
+System prompts and capability tokens live only inside an AWS Nitro Enclave. The orchestrator process can request inference via a typed RPC but never sees prompt plaintext.
+
+**Attack model defeated.** Compromised orchestrator process. Memory scraping. Lateral movement from a co-tenant.
+**Feasibility today.** Medium. 1–2 quarters. Adds AWS lock-in unless paired with TDX/SEV-SNP equivalents. **Prototype in v2, ship in v2.1.**
+
+### Proposal C — ZK-attested tool execution
+
+MCP servers produce a ZK proof that `output = f(schema, input)` for a declared schema-conformant `f`.
+
+**Feasibility today.** Low for general `f`. **Do not prototype in v2.** Revisit when general-purpose ZK-VMs (RISC0, SP1, Jolt) hit sub-10× overhead.
+
+### Proposal D — Per-session prompt salt + rule-selection seed (asymmetric defense)
+
+Aigis generates a per-session random `salt` and a per-session `rule_seed` from a master key. Detection rules incorporate the salt (so an attacker probing a public Aigis can't deterministically reproduce the rule set they will face in production); the rule_seed selects a random subset of equivalent detectors. The algorithm is fully public; only the keys are secret. Stackelberg-style: the defender commits to a distribution.
+
+**Attack model defeated.** Offline jailbreak optimization against a known detector set. "Read the code, find the gap" attacks.
+**Feasibility today.** High. 1–2 engineer-weeks. **Ship in v2.** This is the Kerckhoffs answer to the open-source detector problem.
+
+## 7. The asymmetry argument — what's the "key" in AI security?
+
+| Secret | Role | Maturity |
+|---|---|---|
+| Signing key (developer/vendor) | Authorizes prompts, tools, models | Production |
+| Per-session prompt salt | Defeats offline jailbreak search | Trivial to deploy |
+| Per-session rule-selection seed | Randomized defender strategy | Trivial to deploy |
+| TEE attestation key (hardware root) | Proves enclave identity | Production (Nitro), maturing (NVIDIA CC) |
+| ZK proving/verifying key pair | Attests inference or tool execution | Research for LLM-scale |
+| HE secret key | Hides inputs from model | Research for LLM-scale |
+| C2PA manifest signing key | Output provenance | Production for media, adaptable |
+
+The two underused ones are the **per-session salt** and **rule-selection seed**. They cost nothing and meaningfully change the attacker's economics from "find one bypass" to "find a bypass that works across the salt distribution."
+
+## 8. Honest critique
+
+- **TEEs leak.** SGX has been broken repeatedly: Foreshadow, Plundervolt, SGAxe/CrossTalk, ÆPIC Leak, Downfall. Each was patched, but enclaves on shared silicon have side-channel surface. Nitro Enclaves avoid most of this by VM isolation. GPU TEEs are new enough that their side-channel surface is largely unmapped.
+- **ZK is still 10–1000× overhead.** Worth it for: low-frequency, high-value attestations. Not for: per-token inference, high-throughput tool calls.
+- **HE/MPC for LLM-scale is impractical.** ZAMA's GPT-2 at 11s/token is heroic engineering, but it is GPT-2. A 70B model is roughly 600× the FLOPs.
+- **Formal verification of LLM weights does not exist** and is unlikely to exist for any model whose behavior is interesting. FV of *the code around* the LLM is tractable.
+- **Apple PCC is the gold standard** but relies on Apple's own silicon, build pipeline, and transparency log. Replicating it for a third-party agent stack is multi-year, multi-million-dollar.
+
+## 9. Recommended reading
+
+1. *Confidential LLM Inference: Performance and Cost Across CPU and GPU TEEs* — [arxiv:2509.18886](https://www.arxiv.org/pdf/2509.18886). The numbers you need to make the TEE deployment decision.
+2. *Apple Private Cloud Compute Security Guide* — security.apple.com/documentation/private-cloud-compute.
+3. *Design Patterns for Securing LLM Agents against Prompt Injections* (CaMeL et al.) — [arxiv:2506.08837](https://arxiv.org/pdf/2506.08837).
+4. *zkLLM / NANOZK* — [arxiv:2603.18046](https://arxiv.org/pdf/2603.18046).
+5. *SLSA v1.0 specification* + *Sigstore: Software Signing for Everybody* (CCS '22).
+
+## Top 3 to prototype (rank by effort × impact)
+
+1. **Per-session salt + randomized rule selection.** ~1–2 engineer-weeks. Pure software. Immediately changes attacker economics for the open-source-detector problem. **This is the Kerckhoffs move for Aigis v2.**
+2. **Sigstore + in-toto provenance for MCP tool descriptors and system prompts.** ~2–4 engineer-weeks for MVP. Mature primitives. Cryptographically defeats MCP rug-pull.
+3. **Nitro Enclave companion daemon for system-prompt and capability-token custody.** ~1–2 quarters. Real cloud lock-in but ships a story for regulated buyers.
+
+## Top 3 NOT to prototype yet (too early)
+
+1. **FHE/MPC inference at LLM scale.** Two orders of magnitude too slow. Revisit when sub-10×-overhead transformer inference is published.
+2. **General-purpose ZK-attested tool execution.** Cost asymmetric to schema validation. Revisit when zkVMs (RISC0, SP1, Jolt) hit sub-10× overhead.
+3. **Formal verification of LLM behavior / "verified ML" for safety.** No path to scaling. Invest formal-methods effort in the *guardrail code* instead.

--- a/docs/research/v2-foundations/06-safety-engineering.md
+++ b/docs/research/v2-foundations/06-safety-engineering.md
@@ -1,0 +1,176 @@
+# Safety Engineering & Anti-Fraud Paradigms for Aigis v2
+
+LLM agent security is currently dominated by a CS/ML mindset: pattern detection, model evaluation, red-teaming. But hostile environments with high-stakes failure modes are a *solved-ish* problem in older disciplines — aviation kills people, nuclear melts cities, banks lose billions.
+
+## 1. Safety Engineering Primitives — What Survives the Translation
+
+### Swiss Cheese Model (Reason, 1990)
+Every defensive layer has holes. Failures occur when holes line up. **Measure hole alignment, not individual layer accuracy.** If two layers both miss the same attack category, they aren't independent — they're one layer pretending to be two.
+
+**Aigis proposal:** add a `correlation_matrix` report to `aigis bench` showing which detectors miss the same attacks.
+
+### Defense in Depth (Nuclear)
+A reactor has: fuel pellet matrix → cladding → primary coolant loop → containment vessel → exclusion zone → regulatory oversight. Each layer engineered for a *different* failure class.
+
+### Two-Person Rule
+Nuclear launch, narcotic dispensing, prod DB changes. Two independent agents must agree. **Highest-ROI single import for Aigis.**
+
+**`aigis.dual_control`** — a policy attribute on tools. When `dual_control=True`, the call is forwarded to a second, independently-prompted LLM (different system prompt, ideally different model) that sees only `{tool_name, arguments, brief justification}` and must approve.
+
+```python
+@aigis.tool(dual_control=True, reviewer_model="claude-haiku")
+def delete_files(paths: list[str]): ...
+```
+
+Effort: ~1 week. The reviewer prompt is the hard part — must be independent enough that prompt injection doesn't transfer.
+
+### FMEA — Failure Mode and Effects Analysis
+For each component: what can fail, what's the effect, severity, detectability. Aigis already does this informally. Formalizing would yield `failure_modes.yaml` per detector class.
+
+### STAMP / STPA (Leveson, MIT) — The Most Important Framework Here
+Leveson's claim: most modern accidents are not component failures, they are **control failures**. The classic STPA categorization of unsafe control actions:
+
+1. Control action **not provided** when needed
+2. Control action **provided** when unsafe
+3. Control action provided with **wrong timing/order**
+4. Control action provided with **wrong duration**
+
+Map onto an LLM agent:
+- LLM doesn't call `verify_user_intent` when it should → (1)
+- LLM calls `transfer_funds` based on poisoned email → (2)
+- LLM calls `send_email` before approval comes back → (3)
+- LLM holds a database transaction open indefinitely → (4)
+
+**This generates a deterministic detector catalog** — not a vibes-based one.
+
+### Bow-Tie Analysis
+Left = threats/causes; center = hazard; right = consequences. Barriers on both sides.
+
+**Aigis proposal:** publish `docs/bowties/` with one bow-tie per top attack class (prompt injection, MCP rug-pull, memory poisoning, tool argument tampering). Each barrier maps to a specific detector rule ID.
+
+### Black Box / Flight Data Recorder
+**Aigis proposal:** `aigis.recorder` — append-only signed log of `(prompt, retrieval, tool_calls, detector_verdicts, output)` per agent turn. Compatible with a public incident-report schema.
+
+### NOTAMs / Safety Bulletins
+Aviation broadcasts hazards fleet-wide within hours. CVE is the closest CS analog but slow. See §6 (Visa).
+
+## 2. Military / Intelligence Models — Mostly Bad Fits, One Good One
+
+- **Bell-LaPadula**: designed for static document classification. LLM context is fluid. Poor fit.
+- **Biba**: integrity dual of BLP. "Don't let the agent read low-integrity sources before issuing high-integrity actions" is exactly the prompt-injection-via-retrieval pattern. Worth a look.
+- **Brewer-Nash Chinese Wall**: relevant when the same agent handles multiple tenants.
+- **Clark-Wilson — well-formed transactions, separation of duty**: this *is* the right model. Every tool call should be a well-formed transaction that can only move the system between valid states.
+
+**`aigis.transaction` decorator** — a tool call wrapped in pre/post-condition check. Pre: arguments validate against schema + business rules. Post: side effects match declared effects. Rejected transactions roll back.
+
+- **Cross-domain solutions / data diodes**: one-way information flow. Sandboxed-tool output that the LLM should be able to *read but not act on without review*.
+
+## 3. Anti-Fraud — The Closest Existing Analog
+
+Banking anti-fraud is the discipline closest to "deterministic guardrails on a probabilistic agent."
+
+### Velocity Rules
+Visa flags "5 transactions in 60 seconds across 3 countries." Trivial logic, enormous coverage.
+
+**`aigis.velocity`** — per-(agent, tool) and per-(agent, capability-class) rate limits with adaptive backoff. Effort: ~3 days.
+
+```python
+aigis.velocity.configure(
+    ("agent_id", "fs.write"), max_per_minute=10, burst=20,
+    on_breach="soft_block",
+)
+```
+
+### Behavioral Baselining
+Banks compute a per-cardholder spending baseline; deviations trigger review. Equivalent for agents: per-agent baseline of tool-call distribution, prompt length, retrieval diversity.
+
+**`aigis.baseline`** — collects a 7-day rolling distribution per agent. Cheap, no ML needed.
+
+### Step-Up Authentication
+Low-risk transactions go through; high-risk ones demand more proof.
+
+### Soft Block + Review Queue
+Banks rarely hard-decline ambiguous transactions — they hold them. Far better UX than a hard block and provides labeled training data.
+
+**`aigis.review_queue`** — when a detector returns `verdict=ambiguous`, the call is paused, serialized, and made available to a human reviewer or higher-tier model.
+
+### Reason Codes
+Every Visa decline has a numbered reason code. Aigis already has rule IDs — preserve this strength.
+
+### Shadow Mode for New Rules
+New fraud rules ship in observation mode for weeks before enforcement. **The single biggest discipline gap in current LLM security.**
+
+**`mode=observe`** on every new detector. Telemetry from N runs feeds an automatic promotion check.
+
+### Chargebacks — Economic Feedback
+Banks make merchants pay for fraud they accept. Governance proposal more than code: agent operators should bear cost when their agent causes harm to downstream parties.
+
+## 4. Concrete Proposals for Aigis v2 (Consolidated)
+
+| # | Proposal | Attack class | Effort | API surface |
+|---|---|---|---|---|
+| 1 | `aigis.dual_control` | Destructive tool misuse | 1 week | Tool decorator |
+| 2 | `aigis.velocity` | Runaway loops, exfiltration | 3 days | Middleware config |
+| 3 | `aigis.baseline` | Behavioral drift | 1 week | Background collector |
+| 4 | `aigis.review_queue` | Ambiguous cases, UX | 2 weeks | New subsystem |
+| 5 | `aigis.recorder` | Forensics, compliance | 1 week | Append-only sink |
+| 6 | `aigis.transaction` (Clark-Wilson) | Integrity violations | 2 weeks | Tool decorator |
+| 7 | `mode=observe` lifecycle | New-rule false positives | 1 week | Detector metadata |
+| 8 | STPA-derived detector catalog | Control failures | 4 weeks | Generated rules |
+| 9 | Bow-tie docs per attack class | Compliance, legibility | 2 weeks | `docs/bowties/` |
+
+## 5. The Control-Theory Frame — Why This Might Be the Right Mental Model
+
+Leveson's STAMP argues that pattern detection is structurally insufficient because it treats accidents as component failures. But LLM agents fail like control systems fail: the controller (LLM) acts on a process (the world via tools), with feedback (tool results, retrieval), and the controller has a model (the context window) that diverges from reality over time.
+
+The dominant failure modes match STPA's categories exactly:
+- **Stale context**: the LLM's mental model lags the actual session.
+- **Poisoned feedback**: retrieved documents or tool outputs are adversarial.
+- **Missing feedback**: tool calls succeed silently when the effect is wrong.
+- **Wrong-timing actions**: agent commits before user confirms.
+
+**Implication for Aigis v2:** stop thinking of Aigis as an input filter sitting in front of the LLM. Think of it as a **supervisory controller** that monitors the loop: prompt → action → observation → next prompt. It enforces invariants on the *loop*, not just the messages.
+
+Concretely:
+- Enforce that every tool call has a feedback consumed within N turns ("the controller must read its sensors").
+- Enforce that destructive actions cannot be issued before a confirming observation ("no fire without target lock").
+- Detect when context staleness exceeds a threshold and force a re-grounding step.
+
+This is the largest conceptual shift v2 should make.
+
+## 6. The Visa Lesson — Federation as a Force Multiplier
+
+Visa sees fraud patterns no single bank can. The federation layer is the product. No single Aigis deployment will see the next novel jailbreak; the fleet will.
+
+**Aigis Federation (proposal):** opt-in, privacy-preserving telemetry channel emitting `(rule_id_fired, detector_class, anonymized_pattern_hash, timestamp, deployment_region)`. Aggregate dashboard shows novel-pattern emergence. Subscribers receive new detector rules with a 24-hour SLA, shipped in `mode=observe` by default.
+
+The hard parts are political, not technical: privacy commitments, governance, competitive dynamics.
+
+**This is plausibly Aigis's strongest moat** — single-deployment guardrails commoditize fast; a federation does not.
+
+## 7. Honest Critique
+
+- **Safety engineering assumes stable failure modes.** LLMs fail in continuous, distributional, context-dependent ways. FMEA tables go stale fast. The frameworks help by *structuring thinking*, not by giving definitive enumerations.
+- **Two-person rule has high friction.** Doubling latency and inference cost is unacceptable for low-stakes calls. Use sparingly.
+- **Anti-fraud federation requires data sharing.** Cross-company sharing is hard.
+- **Bell-LaPadula doesn't transfer cleanly.**
+- **STAMP is hard to operationalize.** Best frame, but turning STPA analyses into running code requires discipline most teams won't sustain.
+- **Velocity and baseline rules have a cold-start problem.**
+
+## 8. Recommended Reading
+
+1. **Nancy Leveson, *Engineering a Safer World*** (MIT Press, 2011) — free PDF: https://direct.mit.edu/books/oa-monograph/2908/Engineering-a-Safer-WorldSystems-Thinking-Applied
+2. **Nancy Leveson, *STPA Handbook*** (2018) — free PDF: https://psas.scripts.mit.edu/home/get_file.php?name=STPA_handbook.pdf
+3. **James Reason, *Human Error*** (Cambridge, 1990).
+4. **Diogo Sebastião et al., "Applying STPA to AI safety"** — recent work bringing STPA into ML contexts.
+5. **David Clark & David Wilson, "A Comparison of Commercial and Military Computer Security Policies"** (1987).
+
+## Top 3 to Prototype (Ranked)
+
+1. **STPA-derived detector catalog (`aigis.stpa`)** — the single biggest conceptual upgrade. Run STPA analysis on a representative agent, enumerate unsafe control actions across the four STPA categories, and codegen detector stubs. Highest leverage, highest learning.
+
+2. **`aigis.velocity` + `aigis.review_queue` + `mode=observe` lifecycle** — bundle these three because they together port the anti-fraud operations discipline into Aigis. Converts Aigis from "rule engine" to "fraud operations platform." Mid effort, immediate user-visible value.
+
+3. **`aigis.dual_control` for destructive tools** — narrow, high-leverage, story-tellable. Picks up exactly the prompt-injection-to-destructive-action class. Cheap to ship, easy to demo, defensible in compliance conversations.
+
+Federation (Visa lesson) is the highest *strategic* value but premature until the single-deployment story is solid — defer to v2.x, not v2.0.

--- a/docs/research/v2-foundations/README.md
+++ b/docs/research/v2-foundations/README.md
@@ -1,0 +1,62 @@
+# Aigis v2 Foundations — Cross-Discipline Research
+
+This directory contains research informing the Aigis v2 architecture. The original question:
+
+> 「AIセキュリティってAI側が元のコードからハッキングしてすり抜けるから意味がない、オープンソースや仕組みがAIに渡る時点で防ぎようがない」という議論をクリアする仕組みは作れるか？
+
+That is: **can we design AI security that survives full disclosure of the algorithm?** The cryptographic answer (Kerckhoffs) is yes — but only if the design moves beyond detection. This research surveys six adjacent disciplines for transferable architectural primitives.
+
+## Contents
+
+| File | Discipline | Core insight |
+|---|---|---|
+| `01-immune-system.md` | Biological immunology | Innate + adaptive layers, danger theory (consequences > non-self), graded response (cytokines) |
+| `02-mechanism-design.md` | Game theory / mechanism design | Slashable capability tokens, commit-reveal plans, honeytokens. AIP (arxiv:2603.24775) |
+| `03-os-systems-security.md` | OS / capability systems | Object capabilities, WASI sandbox, Landlock+seccomp, privsep. Wassette / AIP convergence |
+| `04-web-security.md` | Web security model | SOP/CSP/Trusted Types/SRI. Provenance is the load-bearing primitive. CaMeL lineage |
+| `05-cryptography-tee.md` | Cryptography / TEE / ZKP | Per-session salt (Kerckhoffs), Sigstore provenance, Nitro Enclaves. ZK/HE deferred |
+| `06-safety-engineering.md` | Safety engineering / anti-fraud | STAMP/STPA control-loop frame, two-person rule, Visa-style federation, Clark-Wilson |
+| `synthesis.md` | All six | Convergence map, unified v2 architecture, prioritized roadmap |
+
+## TL;DR (read this first)
+
+Six independent research passes converged on the same architectural center:
+
+1. **Capability / Origin / Provenance** — load-bearing primitive named by all 6 disciplines under different names (MHC presentation, capability tokens, object capabilities, SOP, signed manifests, Clark-Wilson transactions).
+2. **Plan / commit before execution** — named by 4 disciplines (commit-reveal, CaMeL static plan, capability grants, STPA "no fire without target lock").
+3. **Graded response, not binary block** — 4 disciplines (cytokine, cost-asymmetric, report-only, review queue).
+4. **Per-session salt / randomized defender strategy** — 3 disciplines (Stackelberg, polymorphic prompt, Kerckhoffs). The direct answer to the open-source-detector problem.
+
+Two specific artifacts were independently recommended by multiple agents:
+
+- **CaMeL** (arxiv:2503.18813, DeepMind 2025) — capability-based dual-LLM with IFC interpreter.
+- **AIP / IBCT** (arxiv:2603.24775, IETF draft 2026) — Invocation-Bound Capability Tokens for MCP.
+
+These should anchor v2.
+
+## Recommended v2 prototype order
+
+| # | Component | Effort | Why |
+|---|---|---|---|
+| 1 | `aigis.salt` — per-session salt + randomized rule selection | 1-2 weeks | Directly answers the open-source-detector problem with the cheapest Kerckhoffs move |
+| 2 | `aigis.origin` — provenance-tagged prompt assembly | 2 weeks | Foundation every other v2 layer depends on (the SOP of LLM security) |
+| 3 | `aigis.tt` — Trusted Types for shell/sql/http tool args | 1-2 weeks/family | Structurally eliminates the "prompts become shells" RCE class |
+| 4 | `aigis.plan` — commit-reveal plan enforcement | 1-2 weeks | Makes mid-flight prompt injection structurally impossible |
+| 5 | `aigis.canary` — honeytoken module | 1-2 days | FP=0 by construction; fastest empirical signal |
+
+Defer to v3: AIP capability tokens (needs ecosystem buy-in), Nitro Enclaves (cloud lock-in), Visa-style federation (governance), ZK/MPC/HE inference (still 10-1000× overhead).
+
+## Conceptual frame
+
+The strongest umbrella framing came from safety engineering: **Aigis v2 should be designed as a supervisory controller on the LLM control loop (Leveson's STAMP), not as an input filter.** Every other discipline's contribution slots into a position on that loop:
+
+- Origin/provenance — controls what information the controller sees
+- Capability — controls what control actions the controller can issue
+- Plan/commit — controls when control actions can be reordered
+- Graded response — controls system response to anomalies
+- Salt/randomization — controls the controller's attack-time predictability
+- Federation — provides fleet-level feedback the controller can't generate alone
+
+## Original research date
+
+Researched 2026-05-26. Sources are dated through 2026-Q2.

--- a/docs/research/v2-foundations/synthesis.md
+++ b/docs/research/v2-foundations/synthesis.md
@@ -1,0 +1,203 @@
+# Synthesis: 6-Discipline Convergence Map for Aigis v2
+
+This document synthesizes the six discipline-specific research memos (`01-immune-system.md` through `06-safety-engineering.md`) into a unified architectural map. The original question being answered:
+
+> 「AIセキュリティってAI側が元のコードからハッキングしてすり抜けるから意味がない、オープンソースや仕組みがAIに渡る時点で防ぎようがない」
+
+Can we design AI security that survives full disclosure of the algorithm? Six independent research passes give a convergent answer: **yes, but only by moving beyond detection into a layered architecture where the load-bearing primitives are structural (capability, origin, plan-commit) rather than statistical (pattern matching).**
+
+## 1. Convergence map — where the disciplines independently agreed
+
+| # | Concept | Disciplines (Σ/6) | Common core |
+|---|---|---|---|
+| 1 | **Capability / Origin / Provenance** | Immune (MHC) · Mechanism · OS · Web · Safety · Crypto | **6/6.** "Structurally distinguish content by its source and the rights that source carries." Named MHC presentation / capability tokens / object capabilities / SOP / signed manifests / Clark-Wilson transactions across disciplines. |
+| 2 | **Plan / commit before execution** | Mechanism · Web · OS · Safety | 4/6. Sign the plan up front; deviation is a hard fault. |
+| 3 | **Graded response (not binary block)** | Immune (cytokine) · Mechanism · Web (report-only) · Safety (review queue) | 4/6. Threshold-based friction escalation. |
+| 4 | **Per-session salt / randomized defender strategy** | Mechanism (Stackelberg) · Web (polymorphic) · Crypto (Kerckhoffs) | 3/6. **Publish the algorithm, keep the seed secret.** Direct answer to the open-source-detector problem. |
+| 5 | **Typed sinks / Trusted Types** | Web · OS (WASI) · Safety (Clark-Wilson) | 3/6. `shell/sql/http` arguments protected at the type level. |
+| 6 | **Federation / fleet-wide signal** | Mechanism · Safety (Visa) · Crypto (Sigstore) | 3/6. Exceed single-deployment visibility limits. |
+| 7 | **Honeytoken / canary** | Mechanism · Immune (danger signal) | 2/6. FP=0 by construction. |
+
+Two specific artifacts were independently recommended by multiple agents:
+
+- **CaMeL** ([arxiv:2503.18813](https://arxiv.org/abs/2503.18813), DeepMind 2025) — capability-based dual-LLM with an IFC interpreter. Named by Mechanism, Web, OS, and Crypto memos.
+- **AIP / IBCT** ([arxiv:2603.24775](https://arxiv.org/abs/2603.24775), IETF draft 2026) — Invocation-Bound Capability Tokens. Named by Mechanism and OS memos.
+
+These should anchor v2.
+
+## 2. The three conceptual pillars
+
+### Pillar A — Capability + Provenance (the architectural center)
+
+The 6/6 convergence point. Every discipline named some version of "the content carries metadata about its origin and the rights that origin confers, and the executor checks this before acting."
+
+Concrete Aigis components that fall under this pillar:
+- `aigis.origin` — origin-tagged prompt assembly (web memo)
+- `aigis.cap` — AIP-compatible capability tokens (mechanism + OS memos)
+- `aigis.attestation` — MHC-style step attestation (immune memo)
+- Sigstore-signed tool descriptors (crypto memo)
+- `aigis.transaction` — Clark-Wilson well-formed transactions (safety memo)
+
+These are different lenses on the same primitive. Implement once, expose multiple APIs.
+
+### Pillar B — STPA / Control-Loop Frame (the conceptual umbrella)
+
+The safety memo's strongest argument: **Aigis v2 should be designed as a supervisory controller on the LLM control loop, not as an input filter.**
+
+Every other discipline's contribution slots into a position on that loop:
+
+```
+                    ┌─────────────────────────────┐
+                    │   LLM (controller)          │
+                    │                             │
+       ┌────────────►  reasoning + tool selection ├──┐
+       │            │                             │  │
+       │            └─────────────────────────────┘  │
+       │                                             ▼
+   ┌───┴─────────────────────────────────────────────────┐
+   │ FEEDBACK CHANNEL                  CONTROL ACTIONS   │
+   │                                                     │
+   │ • origin tags on returns          • capability check│
+   │ • SRI hash verification           • plan-commit chk │
+   │ • staleness detection             • trusted types   │
+   │ • canary scan                     • dual-control    │
+   └─────────────────────────────────────────────────────┘
+                            │
+                            ▼
+                   ┌─────────────────┐
+                   │  Process (world)│
+                   └─────────────────┘
+```
+
+Aigis intervenes on both sides:
+- Feedback channel: origin (web), SRI (web), canary (mechanism), staleness (safety).
+- Control actions: capability (OS), plan (mechanism), Trusted Types (web), dual-control (safety).
+
+Plus the surrounding governance: graded response (immune), velocity rules (safety), federation (safety).
+
+### Pillar C — Kerckhoffs Discipline (the directly-stated answer to the question)
+
+The crypto memo's clearest framing: **the answer to "open-source detectors are bypassable" is to publish everything except a small per-session secret.**
+
+Candidate "keys":
+- Signing key (developer/vendor)
+- Per-session prompt salt
+- Per-session rule-selection seed
+- TEE attestation key
+- C2PA manifest signing key
+
+The two underused ones — per-session salt and rule-selection seed — cost nothing and meaningfully change the attacker's economics from "find one bypass" to "find a bypass that works across the salt distribution."
+
+This pillar is small in code but conceptually load-bearing. It is the answer to the original question.
+
+## 3. Unified v2 architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Conceptual frame: STPA (LLM = controller, Aigis = monitor)│
+└──────────────────────────────────────────────────────────┘
+            ↓
+┌─ Layer 0: Detection (v1, retained) ─────────────────────┐
+│ • pattern.py                                            │
+│ • per-session salt + randomized rule selection          │ ← Kerckhoffs
+├─ Layer 1: Provenance / Origin ──────────────────────────┤
+│ • aigis.origin: tagged prompt fragments                 │ ← 6/6 convergence
+│ • Sigstore-signed tool descriptors                      │
+├─ Layer 2: Capability ───────────────────────────────────┤
+│ • aigis.cap: AIP-compatible tokens                      │ ← 5/6 convergence
+│ • WASI sandbox / Landlock for native tools              │
+├─ Layer 3: Structural defenses ──────────────────────────┤
+│ • aigis.plan: commit-reveal                             │ ← 4/6 convergence
+│ • aigis.tt: Trusted Types for dangerous args            │ ← 3/6 convergence
+├─ Layer 4: Behavioral / Adaptive ────────────────────────┤
+│ • aigis.trace: negative selection on behavior           │
+│ • aigis.cytokine: graded response score                 │ ← 4/6 convergence
+├─ Layer 5: Multi-party approval ─────────────────────────┤
+│ • aigis.dual_control: 2-person rule for destructive ops │
+├─ Layer 6: Tripwires ────────────────────────────────────┤
+│ • aigis.canary: honeytokens                             │
+├─ Layer 7: Operations ───────────────────────────────────┤
+│ • aigis.velocity, review_queue, observe-mode lifecycle  │
+│ • aigis.recorder: tamper-evident black box              │
+└─────────────────────────────────────────────────────────┘
+        ↓
+┌─ Future (v3): Federation + TEE ─────────────────────────┐
+│ Visa-style fleet telemetry / Nitro Enclave hosting      │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 4. Cross-discipline prototype ranking (Top 5 across all 6 memos)
+
+Each agent recommended a Top 3. Aggregating across agents and weighting by convergence count:
+
+| Rank | Component | Effort | Recommended by | Why this rank |
+|---|---|---|---|---|
+| 1 | **`aigis.salt`** — per-session salt + randomized rule selection | 1-2 weeks | Crypto (Top 1) | Direct answer to the original question. Lowest effort. Kerckhoffs guarantee. |
+| 2 | **`aigis.origin`** — provenance tagging | 2 weeks | Web (Top 1) · Crypto (Top 2) · 6/6 convergence | Foundation that every other v2 layer depends on. The SOP of LLM security. |
+| 3 | **`aigis.tt`** — Trusted Types for shell/sql/http args | 1-2 weeks/family | Web (Top 2) · OS · Safety | Structurally eliminates the Microsoft "prompts become shells" RCE class with deterministic code, no patterns. |
+| 4 | **`aigis.plan`** — commit-reveal plans | 1-2 weeks | Mechanism (Top 2) · Web · 4/6 convergence | Makes mid-flight prompt injection structurally impossible. |
+| 5 | **`aigis.canary`** — honeytokens | 1-2 days | Mechanism (Top 1) | FP=0 by construction; fastest empirical signal. |
+
+Layers 1-4 (#1-#4 above) should be the v2.0 core scope. `aigis.canary` (#5) is a slam-dunk side ship — small enough to bundle with any of the above.
+
+## 5. Deferred to v3 (justified by research)
+
+- **AIP capability tokens with slashing** — needs ecosystem buy-in (mechanism memo §4).
+- **Nitro Enclave host** — real cloud lock-in; ship after the orchestrator/guardrail boundary is clean (crypto memo §B).
+- **Visa-style federation** — governance and privacy commitments are the hard part, not code (safety memo §6).
+- **Negative selection trace detector** — requires per-deployment tolerance training, embedding pipeline, eval harness (immune memo §3.B).
+- **STPA-derived detector catalog** — high-leverage but requires sustained discipline (safety memo Top 1).
+
+## 6. Explicit "do not prototype yet" — based on research
+
+From the crypto memo:
+1. **FHE/MPC inference at LLM scale.** Two orders of magnitude too slow.
+2. **General-purpose ZK-attested tool execution.** Cost asymmetric to schema validation.
+3. **Formal verification of LLM behavior.** No path to scaling.
+
+Invest formal-methods effort in the *guardrail code* (Verus/F* for the policy engine), not in the LLM weights.
+
+## 7. Strategic positioning
+
+From the OS memo:
+
+> "Aigis v1 competes in the crowded 'detect bad prompts' space. Aigis v2, if it ships the broker + sandbox combo, becomes the *only* open-source MCP layer that combines (a) deterministic pattern detection, (b) unforgeable capability dispatch, and (c) OS-level isolation under a single policy file."
+
+Add Pillars B (STPA control-loop frame) and C (Kerckhoffs salt), plus the Visa-lesson federation hint for v3, and Aigis v2 has a defensible position that takes years to copy.
+
+## 8. Honest critique across all six memos
+
+Common themes from the "honest critique" sections:
+
+1. **No single primitive defeats the open-source-detector problem alone.** The salt/seed buys economics, the capability layer bounds damage, the origin layer constrains intent inheritance. They compose multiplicatively.
+
+2. **Every structural defense introduces friction.** Two-person rule doubles latency. Commit-reveal plans constrain agent flexibility. Trusted Types require schema engineering. The deployments that adopt them first will be the ones that can absorb the friction (regulated industries, high-stakes domains). This is fine — Aigis doesn't need 100% of the market.
+
+3. **The frameworks help by structuring thinking, not by giving definitive enumerations.** STPA, FMEA, immune metaphors — none of them produce a closed-form rule set. Use them as conceptual scaffolding, then engineer specifics.
+
+4. **Mechanism design needs identifiable players.** Pre-AIP, MCP has no identity layer. Aigis should hard-couple to whatever identity layer emerges (AIP is the current best candidate).
+
+5. **Open source attackers reading the immune layers too.** Pattern + negative-selection + danger + memory raises *cost* of bypass; it doesn't eliminate bypass. The only true Kerckhoffs guarantee comes from the per-session secret (Pillar C).
+
+## 9. Original-question check
+
+The opening claim was: "AIセキュリティは仕組みが渡る時点で防ぎようがない." Reformulated answer based on six disciplines:
+
+**Yes, if the security is detection-only.** No, if the security is layered with structural primitives whose strength does not depend on rule secrecy:
+
+- **Capability** (OS, mechanism, immune): the algorithm is public; the unforgeable handles are session-scoped secrets.
+- **Origin** (web, immune, crypto): the algorithm is public; the per-fragment tags are integrity-protected.
+- **Plan-commit** (mechanism, web, safety): the algorithm is public; the per-session plan hash is the commitment.
+- **Trusted Types** (web, OS, safety): the parser is public; the *parse* either succeeds against schema or it doesn't.
+- **Per-session salt** (crypto, mechanism, web): the algorithm is public; the salt is the key. This is the textbook Kerckhoffs answer.
+
+The Kerckhoffs move (Pillar C) is the *direct* technical answer. The other pillars (A, B) make detection-free security *feasible* at all.
+
+## 10. Roadmap suggestion
+
+Phase 1 (v2.0, ~6-8 weeks): Layers 0-3 with the Top 5 prototypes.
+Phase 2 (v2.1, ~quarter): Layer 4 (graded response, behavioral baselining), Layer 5 (dual-control).
+Phase 3 (v2.2, ~quarter): Layer 6-7 (canaries already from Phase 1; recorder, velocity, observe-mode).
+Phase 4 (v3, multi-quarter): AIP integration, Nitro Enclave, federation. Each is a moat-grade investment with ecosystem dependencies.
+
+This sequencing front-loads the Kerckhoffs guarantee (Phase 1) so the open-source-detector concern is addressed in the first release, then progressively adds the structural defenses.


### PR DESCRIPTION
## Summary

Aigis v2 のアーキテクチャ検討のための分野横断リサーチを `docs/research/v2-foundations/` に追加。

**元の問い**: 「AIセキュリティってAI側が元のコードからハッキングしてすり抜けるから意味がない、オープンソースや仕組みがAIに渡る時点で防ぎようがない」という議論をクリアする仕組みは作れるか？

6分野（免疫系・メカニズムデザイン・OS/capability・Webセキュリティ・暗号/TEE・安全工学）から独立に調査し、収束点を統合。

## 構成

| ファイル | 分野 | 中核 |
|---|---|---|
| `README.md` | - | 全体マップと v2 prototype 優先順位 |
| `01-immune-system.md` | 免疫系 | innate+adaptive、danger theory、cytokine |
| `02-mechanism-design.md` | ゲーム理論 | slashing、AIP、commit-reveal |
| `03-os-systems-security.md` | OS | capability、WASI、Landlock、Wassette |
| `04-web-security.md` | Web | SOP/CSP/Trusted Types、CaMeL |
| `05-cryptography-tee.md` | 暗号/TEE | Kerckhoffs salt、Sigstore、Nitro Enclaves |
| `06-safety-engineering.md` | 安全工学 | STPA、two-person rule、Visa federation |
| `synthesis.md` | 統合 | 収束マップ、統合 v2 アーキテクチャ、ロードマップ |

## 主要な収束点

1. **Capability / Origin / Provenance** — 6/6分野で独立に言及
2. **Plan / commit before execution** — 4/6分野
3. **Graded response（binary block ではない）** — 4/6分野
4. **Per-session salt / randomized defender strategy** — 3/6分野（**元の問いへの直接的回答 = Kerckhoffs 原理**）

## v2.0 推奨 prototype 順

1. `aigis.salt` — per-session salt + randomized rule selection（1-2週間）
2. `aigis.origin` — provenance-tagged prompt assembly（2週間）
3. `aigis.tt` — Trusted Types for shell/sql/http tool args（1-2週間/family）
4. `aigis.plan` — commit-reveal plan enforcement（1-2週間）
5. `aigis.canary` — honeytoken module（1-2日）

詳細は `synthesis.md` 参照。ドキュメントのみ、コード変更なし。