### PR TITLE
fix(auto-improvement): paper-review fails loud on auth + restores state propagation

### DIFF
--- a/.github/workflows/paper-review.yml
+++ b/.github/workflows/paper-review.yml
@@ -57,6 +57,18 @@ jobs:
       - name: Install anthropic SDK
         run: uv pip install --system "anthropic>=0.40.0"
 
+      - name: Verify ANTHROPIC_API_KEY is set
+        if: ${{ inputs.dry_run != 'true' }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not configured for this repository."
+            echo "Set it under Settings → Secrets and variables → Actions before scheduling this workflow."
+            echo "Skipping silently would file a misleading '0 candidates' issue every day (see #93/#95/#96)."
+            exit 1
+          fi
+
       - name: Run paper review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -87,7 +99,11 @@ jobs:
           git add auto-improvement/
           git commit -m "auto-improvement: daily paper review ${DATE}"
           git push -u origin "$BRANCH"
+          # NOTE: do not swallow gh failure with `|| true`. The auto-improvement
+          # label must exist (created 2026-05-30 after #93/#95/#96 triage), and
+          # if PR creation fails for any other reason we want the workflow red
+          # so state.json never silently fails to land on master.
           gh pr create \
             --title "auto-improvement: daily paper review ${DATE}" \
             --body "Bot PR with the daily batch of pending/ stubs and updated state. See the linked issue for the candidate list." \
-            --label "auto-improvement" || true
+            --label "auto-improvement"

--- a/auto-improvement/scripts/paper_review.py
+++ b/auto-improvement/scripts/paper_review.py
@@ -193,6 +193,35 @@ def pick_unseen(entries: list[Entry], seen: dict, limit: int) -> list[Entry]:
     return fresh[:limit]
 
 
+class JudgeAuthError(RuntimeError):
+    """Raised when the Anthropic SDK cannot authenticate (missing/invalid key).
+
+    Surfaced separately from per-paper errors so the loop can abort the entire
+    run cleanly instead of marking every paper as "judge error: ..." and
+    advancing state past unjudged entries (see issues #93 / #95 / #96).
+    """
+
+
+def _is_auth_error(exc: Exception) -> bool:
+    """Heuristic: does this exception look like a missing/invalid API key?
+
+    Anthropic SDK raises ``anthropic.AuthenticationError`` / ``PermissionDeniedError``
+    on a bad key, but the most common production failure mode is the SDK's
+    "Could not resolve authentication method" RuntimeError when no key is
+    available at all. Match all three by class name + message keywords so we
+    don't have to import the SDK just for `isinstance` checks.
+    """
+    name = type(exc).__name__
+    if name in {"AuthenticationError", "PermissionDeniedError"}:
+        return True
+    text = str(exc).lower()
+    return (
+        "could not resolve authentication method" in text
+        or "expected one of api_key" in text
+        or "x-api-key" in text and "authorization" in text
+    )
+
+
 def judge_with_anthropic(entry: Entry) -> Verdict:
     import anthropic  # noqa: PLC0415 — optional dep, only needed in non-dry-run
 
@@ -407,16 +436,33 @@ def run(argv: Iterable[str] | None = None) -> int:
 
     batch: list[tuple[Entry, Verdict]] = []
     pending_paths: list[Path] = []
+    judge_errors: list[tuple[Entry, Exception]] = []
     for entry in picked:
         try:
             verdict = judge_with_anthropic(entry)
-        except Exception as exc:  # pragma: no cover — surfaced in the issue body
+        except Exception as exc:  # pragma: no cover — surfaced in run summary
+            # Abort the entire run on the first auth failure: every subsequent
+            # call would fail the same way, and marking unjudged papers as
+            # `seen` would permanently skip them once the credential is fixed
+            # (which is exactly what produced issues #93 / #95 / #96).
+            if _is_auth_error(exc):
+                print(
+                    "FATAL: anthropic auth failed — aborting run without writing state "
+                    f"or opening an issue. Fix ANTHROPIC_API_KEY and retry. "
+                    f"({type(exc).__name__}: {exc})",
+                    file=sys.stderr,
+                )
+                raise JudgeAuthError(str(exc)) from exc
             print(f"WARN: judge failed for {entry.title!r}: {exc}", file=sys.stderr)
-            verdict = Verdict(False, None, None, f"judge error: {exc}", None, "")
+            judge_errors.append((entry, exc))
+            # Skip this entry entirely: don't add to batch, don't mark seen.
+            # Tomorrow's run will pick it up again so we don't silently lose it.
+            continue
         batch.append((entry, verdict))
         if verdict.relevant:
             pending_paths.append(write_pending(entry, verdict, today))
-        # Mark seen regardless of verdict so we don't re-judge it tomorrow.
+        # Mark seen only after a successful judge call so we don't permanently
+        # skip a paper that failed transiently.
         state["seen"][entry.key] = {
             "title": entry.title,
             "date": entry.date,
@@ -425,6 +471,17 @@ def run(argv: Iterable[str] | None = None) -> int:
             "first_seen_utc": now.isoformat(timespec="seconds") + "Z",
             "relevant": verdict.relevant,
         }
+
+    if not batch:
+        # Every paper errored individually (rate limits, parse errors, etc).
+        # Don't open a misleading "0 candidates" issue — exit non-zero so the
+        # workflow shows red and the maintainer notices.
+        err_lines = "\n".join(f"  - {e.title!r}: {exc}" for e, exc in judge_errors)
+        print(
+            f"FATAL: all {len(picked)} papers failed to be judged this run:\n{err_lines}",
+            file=sys.stderr,
+        )
+        return 3
 
     research_path = write_research(today_path, [(e, v) for e, v in batch], args.source_url)
 
@@ -452,4 +509,9 @@ def run(argv: Iterable[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(run())
+    try:
+        raise SystemExit(run())
+    except JudgeAuthError:
+        # Already logged a clear FATAL above. Exit 4 so the workflow step
+        # fails red without dumping a noisy Python traceback.
+        raise SystemExit(4)

--- a/auto-improvement/scripts/test_paper_review.py
+++ b/auto-improvement/scripts/test_paper_review.py
@@ -1,0 +1,157 @@
+"""Regression tests for the paper-review loop's failure handling.
+
+These tests cover the fix for issues #93 / #95 / #96, where every paper
+review run produced a misleading "0 candidates" issue because all judge
+calls were failing with an Anthropic auth error and the script swallowed
+the exception as ``relevant=False``.
+
+Run with:
+    python -m pytest auto-improvement/scripts/test_paper_review.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Make the script importable as a module.
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import paper_review  # noqa: E402
+
+
+@pytest.fixture
+def tmp_state(monkeypatch, tmp_path: Path) -> Path:
+    state_path = tmp_path / "state.json"
+    pending_dir = tmp_path / "pending"
+    research_dir = tmp_path / "research"
+    pending_dir.mkdir()
+    research_dir.mkdir()
+    monkeypatch.setattr(paper_review, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(paper_review, "STATE_PATH", state_path)
+    monkeypatch.setattr(paper_review, "PENDING_DIR", pending_dir)
+    monkeypatch.setattr(paper_review, "RESEARCH_DIR", research_dir)
+    return state_path
+
+
+def _fake_entries(n: int) -> list[paper_review.Entry]:
+    return [
+        paper_review.Entry(
+            section="test",
+            title=f"Paper {i}",
+            venue="arXiv",
+            date="2026.01.0" + str(i + 1),
+            url=f"https://arxiv.org/abs/0000.{i:04d}",
+        )
+        for i in range(n)
+    ]
+
+
+def test_auth_error_aborts_without_writing_state(tmp_state, monkeypatch):
+    """When the first judge call fails with an auth error, the script must:
+
+    - exit non-zero (raise JudgeAuthError → SystemExit(4) at the entry point);
+    - not write paper_review_state.json;
+    - not open the misleading "0 candidates" GitHub issue.
+
+    This is the exact failure mode that produced #93/#95/#96.
+    """
+    entries = _fake_entries(3)
+    monkeypatch.setattr(paper_review, "fetch_source", lambda url: "")
+    monkeypatch.setattr(paper_review, "parse_entries", lambda text: entries)
+
+    def boom(_entry):
+        raise RuntimeError(
+            "Could not resolve authentication method. Expected one of api_key, "
+            "auth_token, or credentials to be set."
+        )
+
+    monkeypatch.setattr(paper_review, "judge_with_anthropic", boom)
+    issue_opener = mock.MagicMock()
+    monkeypatch.setattr(paper_review, "open_issue", issue_opener)
+
+    with pytest.raises(paper_review.JudgeAuthError):
+        paper_review.run(["--max-papers", "3"])
+
+    assert not tmp_state.exists(), "state.json must not be written when auth fails"
+    issue_opener.assert_not_called()
+
+
+def test_per_paper_error_does_not_mark_seen(tmp_state, monkeypatch):
+    """A non-auth exception on one paper must skip that paper (no `seen` entry)
+    while still letting the rest of the batch proceed.
+
+    Previous behaviour marked the failed paper as `seen` with relevant=False,
+    silently retiring it from future runs once the credential was fixed.
+    """
+    entries = _fake_entries(3)
+    monkeypatch.setattr(paper_review, "fetch_source", lambda url: "")
+    monkeypatch.setattr(paper_review, "parse_entries", lambda text: entries)
+
+    calls = {"n": 0}
+
+    def flaky(entry):
+        calls["n"] += 1
+        if entry.title == "Paper 1":
+            raise ValueError("transient parse error")
+        return paper_review.Verdict(
+            relevant=False,
+            rule_id=None,
+            rule_category=None,
+            one_line="not relevant",
+            blocked_example=None,
+            source_evidence="",
+        )
+
+    monkeypatch.setattr(paper_review, "judge_with_anthropic", flaky)
+    monkeypatch.setattr(paper_review, "open_issue", lambda *a, **k: None)
+
+    rc = paper_review.run(["--max-papers", "3"])
+    assert rc == 0, "Run should succeed when at least one paper was judged"
+
+    state = json.loads(tmp_state.read_text(encoding="utf-8"))
+    seen_titles = {v["title"] for v in state["seen"].values()}
+    assert seen_titles == {"Paper 0", "Paper 2"}, (
+        "Only successfully-judged papers should be marked seen; "
+        f"got {seen_titles}"
+    )
+
+
+def test_all_papers_error_returns_nonzero(tmp_state, monkeypatch):
+    """If every paper fails with a non-auth error, exit non-zero and skip
+    the issue write — don't spam a misleading '0 candidates' issue."""
+    entries = _fake_entries(2)
+    monkeypatch.setattr(paper_review, "fetch_source", lambda url: "")
+    monkeypatch.setattr(paper_review, "parse_entries", lambda text: entries)
+
+    def always_fail(_entry):
+        raise ValueError("transient")
+
+    monkeypatch.setattr(paper_review, "judge_with_anthropic", always_fail)
+    issue_opener = mock.MagicMock()
+    monkeypatch.setattr(paper_review, "open_issue", issue_opener)
+
+    rc = paper_review.run(["--max-papers", "2"])
+    assert rc == 3
+    issue_opener.assert_not_called()
+
+
+def test_is_auth_error_matches_real_sdk_message():
+    """Smoke check on the heuristic used to detect SDK auth errors."""
+    real = RuntimeError(
+        "Could not resolve authentication method. Expected one of api_key, "
+        "auth_token, or credentials to be set. Or for one of the `X-Api-Key` "
+        "or `Authorization` headers to be explicitly omitted"
+    )
+    assert paper_review._is_auth_error(real)
+
+    class AuthenticationError(Exception):
+        pass
+
+    assert paper_review._is_auth_error(AuthenticationError("bad key"))
+    assert not paper_review._is_auth_error(ValueError("totally unrelated"))


### PR DESCRIPTION
Fixes #93, #95, #96.

## Why

The daily paper-review workflow has been filing a misleading "10 papers reviewed, 0 candidate rule(s)" issue every day since 2026-05-27 (and producing an identical-content issue daily). Run log inspection (workflow run 26491484349, 2026-05-27 04:50 UTC) showed two independent failure modes that compounded:

1. **`ANTHROPIC_API_KEY` is not configured in repo secrets.** Every judge call returned `Could not resolve authentication method`. The script caught the exception, wrote `relevant=False` for all 10 papers, marked them as `seen`, and filed the "0 candidates" summary.

2. **The `auto-improvement` label did not exist in the repo.** `gh pr create --label "auto-improvement" || true` silently swallowed the failure, so the bot branch `bot/paper-review/YYYY-MM-DD` was pushed but no PR was ever opened. With no PR landing on master, `paper_review_state.json` stayed at `{"seen": {}, "runs": []}` on master and every subsequent run reprocessed the same 10 papers.

The `auto-improvement` label has already been created out of band (2026-05-30) so future bot PRs can be opened. This PR addresses the script + workflow contracts.

## What

- `auto-improvement/scripts/paper_review.py`
  - New `JudgeAuthError` + `_is_auth_error()` heuristic (matches the real SDK error class names *and* the no-key RuntimeError message).
  - On the first auth failure: abort the run with exit code 4. `state.json` is **not** written; no issue is filed. The workflow goes red so the maintainer notices.
  - On a per-paper non-auth failure: skip the entry (don't mark `seen`, don't add to batch). The same paper will be retried on the next run instead of being silently retired.
  - If every paper in the batch errored individually: exit 3 without opening a misleading "0 candidates" issue.
- `auto-improvement/scripts/test_paper_review.py` (new)
  - 4 regression tests covering the new failure-mode contracts.
- `.github/workflows/paper-review.yml`
  - Add an explicit `ANTHROPIC_API_KEY is set` precheck with a clear actionable error message.
  - Drop the `|| true` on `gh pr create` so PR creation failures (label missing, branch protection, etc.) no longer hide silently.

## Action items NOT covered by this PR

- [ ] **Set `ANTHROPIC_API_KEY` in repo Actions secrets** (owner only). Without this the workflow will keep failing red, but at least it will fail visibly rather than spamming false issues.
- [ ] After secret is set, run the workflow manually (`workflow_dispatch`) to verify state propagation end-to-end.
- [ ] Decide what to do with the stale `bot/paper-review/2026-05-{19..27}` branches (cumulative state lives on 5/23 and 5/27 only; the rest can be deleted).
- [ ] Close #93 and #95 as duplicates of #96 once this lands.

## Tests

`uv run pytest --tb=no -q` (main suite, excluding `auto-improvement/`): **1673 passed**.
`uv run --with pytest --with anthropic python -m pytest auto-improvement/scripts/test_paper_review.py -q`: **4 passed**.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>