### PR TITLE
feat(forwarders): SIEM/log-lake forwarder layer (ECS 8.x + HTTPS JSON) — closes foundation of #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,45 @@ what got documented across releases.
 
 ### Added
 
+- **`aigis/forwarders/`** — Tier-4 SIEM / log-lake forwarder layer that
+  mirrors every `ActivityEvent` to external systems (Splunk HEC, Elastic,
+  Microsoft Sentinel, Datadog, in-house ingest endpoints) for audit, insider
+  threat analytics, and SOC integration. Adds:
+
+  - `LogForwarder` abstract base with a bounded background queue, batching,
+    exception isolation, and a `Redactor` protocol that runs *before* the
+    schema mapper so PIPA / GDPR data-minimization can strip rule
+    sample text before it leaves the process.
+  - `ECSMapper` (`aigis/forwarders/schema/ecs.py`) producing Elastic Common
+    Schema 8.11.0 documents — natively indexed by Elastic Security and Wazuh,
+    DCR-ingestible by Sentinel, and CIM-derivable for Splunk. Preserves
+    every Aigis-native field under an `aigis.*` namespace so analysts never
+    lose the original `matched_rules`, `owasp_refs`, `delegation_chain`,
+    `autonomy_level`, or policy `decision`.
+  - `HTTPJsonForwarder` — stdlib-only HTTPS POST sink with NDJSON / array
+    body formats, optional gzip, configurable retries with exponential
+    backoff, and 4xx-vs-5xx-aware retry policy. Suitable for Splunk HEC,
+    Datadog Logs, Sentinel custom DCRs, and generic in-VPC ingest endpoints.
+  - `ActivityStream.add_forwarder()` / `remove_forwarder()` /
+    `close_forwarders()` registration API. The on-disk JSONL tiers
+    (local / global / alerts) remain authoritative — forwarders are mirrors,
+    never replacements, and a misbehaving SIEM cannot stop the agent.
+
+  Zero new required dependencies — the foundation, ECS mapper, and HTTPS
+  sink all use only the Python standard library, preserving Aigis' zero-dep
+  core. Lands the Phase 3 ROADMAP item (SIEM integration) as a vertical
+  slice; design discussed in
+  [#98](https://github.com/killertcell428/aigis/issues/98).
+
+  Tests: 19 new in `tests/test_forwarders.py` covering ECS field mapping
+  (including `aigis.*` field preservation and `policy_decision="error"`
+  → `event.outcome="failure"`), HTTPS round-trip against an in-process
+  collector, retry on 5xx and fail-fast on 4xx, gzip / NDJSON / array
+  body formats, the `Redactor` protocol including chained-redactor
+  ordering, bounded queue degradation under load, `close()` drain on
+  graceful shutdown, and end-to-end `ActivityStream` integration
+  (including the broken-forwarder-must-not-break-record invariant).
+
 - **LangGraph two-position guard example and walkthrough** (issue #31) — Adds a
   runnable end-to-end example (`examples/langgraph_guarded_agent.py`) that wires
   `AigisGuardNode` into a `StateGraph` at both the **pre-LLM** (input scan) and

--- a/aigis/activity.py
+++ b/aigis/activity.py
@@ -26,11 +26,17 @@ import csv
 import getpass
 import gzip
 import json
+import logging
 from collections.abc import Generator
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aigis.forwarders.base import LogForwarder
+
+_forwarder_log = logging.getLogger("aigis.activity.forwarders")
 
 # Default retention periods
 LOG_RETENTION_DAYS = 60  # Full logs kept for 60 days
@@ -156,6 +162,37 @@ class ActivityStream:
             self.alert_dir = _global_dir() / "alerts"
             self.alert_dir.mkdir(parents=True, exist_ok=True)
 
+        # Tier 4 (optional): External SIEM / log-lake forwarders. Hot-path
+        # never blocks on these — see aigis.forwarders for the dispatch model.
+        # The on-disk JSONL tiers above remain authoritative.
+        self._forwarders: list[LogForwarder] = []
+
+    # === Forwarder registration (SIEM, log lake, message bus) ===
+
+    def add_forwarder(self, forwarder: LogForwarder) -> None:
+        """Register a forwarder to receive every recorded event.
+
+        Forwarders run on background threads with bounded queues and never
+        block ``record()``. They are mirrors, not replacements: the on-disk
+        JSONL tiers continue to be written unconditionally.
+        """
+        self._forwarders.append(forwarder)
+
+    def remove_forwarder(self, forwarder: LogForwarder) -> None:
+        """Unregister a previously added forwarder. Does not close it."""
+        try:
+            self._forwarders.remove(forwarder)
+        except ValueError:
+            pass
+
+    def close_forwarders(self, timeout: float = 5.0) -> None:
+        """Flush and stop all registered forwarders. Idempotent."""
+        for fwd in self._forwarders:
+            try:
+                fwd.close(timeout=timeout)
+            except Exception:  # noqa: BLE001
+                _forwarder_log.exception("forwarder close failed")
+
     def _log_path(self, base_dir: Path, date: str | None = None) -> Path:
         if date is None:
             date = datetime.now(UTC).strftime("%Y-%m-%d")
@@ -175,6 +212,17 @@ class ActivityStream:
         # Tier 3: Alert archive (permanent, alerts only)
         if self.enable_alerts and event.is_alert:
             self._append(self._log_path(self.alert_dir), line)
+
+        # Tier 4: External forwarders (SIEM, log lake, etc.). Non-blocking,
+        # exception-isolated — a misconfigured SIEM must never stop the agent.
+        for fwd in self._forwarders:
+            try:
+                fwd.submit(event)
+            except Exception:  # noqa: BLE001
+                _forwarder_log.exception(
+                    "forwarder %s.submit raised; event is still in local JSONL",
+                    type(fwd).__name__,
+                )
 
     def _append(self, path: Path, line: str) -> None:
         """Atomic append to JSONL file."""

--- a/aigis/forwarders/__init__.py
+++ b/aigis/forwarders/__init__.py
@@ -1,0 +1,61 @@
+"""SIEM / log forwarders for Aigis.
+
+Forwarders are optional sinks that mirror :class:`aigis.activity.ActivityEvent`
+records into external systems (SIEMs, log lakes, message buses) for audit,
+insider-threat analytics, and SOC integration. They run alongside the existing
+local / global / alert JSONL tiers documented in :mod:`aigis.activity` — never
+in place of them — so the on-disk audit trail and the
+:class:`aigis.audit.SignedAuditLog` tamper-evident chain remain authoritative.
+
+Design goals:
+
+* **Hot-path non-blocking** — ``ActivityStream.record()`` enqueues onto a
+  bounded background queue. Forwarder I/O never blocks an agent tool call.
+* **Zero new required deps** — the base ABC, the ECS schema mapper, and the
+  generic HTTP sink use only the Python standard library, preserving Aigis'
+  zero-dependency core (see ``pyproject.toml``).
+* **PII safety by default** — a :class:`Redactor` hook runs *before* the event
+  ever leaves the process, so PIPA / ISMS-P deployments can strip rule sample
+  text and other sensitive fields before they reach a SIEM operated by a
+  different data controller.
+* **Schema-stable wire format** — the default schema is Elastic Common Schema
+  (ECS) 8.x, which is consumed natively by Elastic, ingested by Microsoft
+  Sentinel via the Log Ingestion API, and re-mappable to Splunk CIM. CEF /
+  OCSF mappers can be added without changing the dispatch path.
+
+Quick start::
+
+    from aigis.activity import ActivityStream
+    from aigis.forwarders import HTTPJsonForwarder
+    from aigis.forwarders.schema import ECSMapper
+
+    stream = ActivityStream()
+    stream.add_forwarder(
+        HTTPJsonForwarder(
+            url="https://siem.internal/api/aigis",
+            headers={"Authorization": "Bearer <token>"},
+            mapper=ECSMapper(dataset="aigis.activity"),
+        )
+    )
+
+All public symbols re-exported here are stable; the submodules
+(:mod:`aigis.forwarders.base`, :mod:`aigis.forwarders.http_json`,
+:mod:`aigis.forwarders.schema`) are also importable directly.
+"""
+
+from aigis.forwarders.base import (
+    ForwarderError,
+    LogForwarder,
+    Redactor,
+)
+from aigis.forwarders.http_json import HTTPJsonForwarder
+from aigis.forwarders.schema import ECSMapper, EventMapper
+
+__all__ = [
+    "ECSMapper",
+    "EventMapper",
+    "ForwarderError",
+    "HTTPJsonForwarder",
+    "LogForwarder",
+    "Redactor",
+]

--- a/aigis/forwarders/base.py
+++ b/aigis/forwarders/base.py
@@ -1,0 +1,233 @@
+"""Forwarder base classes and the background dispatch queue.
+
+A :class:`LogForwarder` is a thin pipeline: ``ActivityEvent -> map -> redact ->
+serialize -> ship``. The dispatch worker runs on a daemon thread and pulls from
+a bounded ``queue.Queue``. If the queue saturates (e.g. SIEM is down or slow)
+we drop the oldest pending event rather than block the producer — the
+authoritative copy is still on disk via :class:`aigis.activity.ActivityStream`'s
+local / global / alerts tiers.
+
+Subclasses implement :meth:`LogForwarder._ship` to actually deliver bytes to
+the upstream system (HTTPS POST, UDP syslog, AMQP publish, etc.). Everything
+else — batching, retries, error isolation, schema mapping, redaction — is
+provided here so that adding a new transport is roughly fifty lines.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from aigis.activity import ActivityEvent
+    from aigis.forwarders.schema import EventMapper
+
+_log = logging.getLogger("aigis.forwarders")
+
+# Default bounded queue size. SIEM forwarders are best-effort — the local
+# JSONL tier remains the source of truth — so we cap memory rather than block.
+DEFAULT_QUEUE_SIZE = 10_000
+
+# Default batch size and flush interval. Batching reduces per-event HTTP
+# overhead without delaying alerts by more than a second under load.
+DEFAULT_BATCH_SIZE = 50
+DEFAULT_FLUSH_INTERVAL = 1.0
+
+
+class ForwarderError(Exception):
+    """Raised when a transport-level failure cannot be recovered.
+
+    Forwarders catch transient failures and apply their own retry policy;
+    this exception is reserved for unrecoverable misconfiguration (bad URL,
+    auth permanently rejected, etc.) and is only raised from the constructor
+    or :meth:`LogForwarder.close`.
+    """
+
+
+@runtime_checkable
+class Redactor(Protocol):
+    """Hook that scrubs an event in-place before it leaves the process.
+
+    Implementations receive a plain ``dict`` produced by
+    :meth:`aigis.activity.ActivityEvent.to_dict` and may mutate it freely.
+    Typical responsibilities:
+
+    * mask original-rule sample text in ``details`` / ``matched_rules`` to
+      satisfy 개인정보보호법 / GDPR data-minimization,
+    * truncate oversized fields (``target`` may be a long shell command),
+    * drop fields the downstream system has no business seeing.
+
+    Redactors run *before* the mapper, so they operate on the raw Aigis
+    schema, not on ECS / CEF wire fields.
+    """
+
+    def redact(self, event: dict) -> dict:
+        """Return the scrubbed event. Mutating the input in-place is fine."""
+        ...
+
+
+class LogForwarder(ABC):
+    """Abstract base for any external sink.
+
+    Subclasses override :meth:`_ship` (and optionally :meth:`close`).
+    Everything else — the queue, the worker thread, batching, redaction,
+    mapping, error isolation — is handled here.
+
+    Thread-safety: :meth:`submit` is safe to call from any thread. The
+    worker runs on a single background daemon thread per forwarder
+    instance.
+    """
+
+    def __init__(
+        self,
+        *,
+        mapper: EventMapper | None = None,
+        redactors: Iterable[Redactor] | None = None,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        flush_interval: float = DEFAULT_FLUSH_INTERVAL,
+    ) -> None:
+        # Lazy import — avoids circular import with aigis.forwarders.schema
+        # and keeps the base module importable in isolation.
+        if mapper is None:
+            from aigis.forwarders.schema import ECSMapper
+
+            mapper = ECSMapper()
+
+        self._mapper: EventMapper = mapper
+        self._redactors: tuple[Redactor, ...] = tuple(redactors or ())
+        self._queue: queue.Queue[dict | None] = queue.Queue(maxsize=queue_size)
+        self._batch_size = max(1, batch_size)
+        self._flush_interval = max(0.05, flush_interval)
+        self._dropped = 0
+        self._sent = 0
+        self._stop = threading.Event()
+        self._worker = threading.Thread(
+            target=self._run, name=f"aigis-forwarder:{type(self).__name__}", daemon=True
+        )
+        self._worker.start()
+
+    # -- Public API ---------------------------------------------------------
+
+    def submit(self, event: ActivityEvent) -> None:
+        """Enqueue an event for asynchronous delivery.
+
+        Never blocks and never raises: if the queue is full, the oldest
+        pending event is discarded and a counter is incremented so the
+        condition is observable via :attr:`stats`. The on-disk JSONL tier
+        keeps the authoritative copy regardless.
+        """
+        try:
+            payload = event.to_dict()
+        except Exception:  # noqa: BLE001 — never let serialization kill the host
+            _log.exception("forwarder: event.to_dict() failed; dropping event")
+            self._dropped += 1
+            return
+
+        # Redact before the event reaches the worker — keeps sensitive
+        # fields out of memory longer than necessary.
+        for redactor in self._redactors:
+            try:
+                payload = redactor.redact(payload)
+            except Exception:  # noqa: BLE001
+                _log.exception("forwarder: redactor %s failed; dropping event", redactor)
+                self._dropped += 1
+                return
+
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            # Bounded queue: drop oldest, enqueue newest. SIEM ingestion
+            # should never starve the agent.
+            try:
+                self._queue.get_nowait()
+                self._dropped += 1
+            except queue.Empty:
+                pass
+            try:
+                self._queue.put_nowait(payload)
+            except queue.Full:
+                self._dropped += 1
+
+    def close(self, timeout: float = 5.0) -> None:
+        """Flush pending events and stop the worker thread."""
+        self._stop.set()
+        # Sentinel wakes the worker if it is parked on Queue.get().
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+        self._worker.join(timeout=timeout)
+
+    @property
+    def stats(self) -> dict[str, int]:
+        """Return delivery counters. Useful for /aig doctor."""
+        return {
+            "sent": self._sent,
+            "dropped": self._dropped,
+            "queued": self._queue.qsize(),
+        }
+
+    # -- Subclass hook ------------------------------------------------------
+
+    @abstractmethod
+    def _ship(self, batch: list[dict]) -> None:
+        """Deliver a batch of mapped, serialized-ready event dicts.
+
+        ``batch`` items are the output of the mapper after redaction. Raise
+        any exception on transient failure — the worker logs it and the
+        events are considered dropped (they are already persisted on disk).
+        Subclasses that need durable retries should implement their own
+        retry-and-backoff inside ``_ship``.
+        """
+
+    # -- Internal worker ----------------------------------------------------
+
+    def _run(self) -> None:
+        batch: list[dict] = []
+        last_flush = time.monotonic()
+
+        while not self._stop.is_set() or not self._queue.empty():
+            timeout = max(0.0, self._flush_interval - (time.monotonic() - last_flush))
+            try:
+                item = self._queue.get(timeout=timeout)
+            except queue.Empty:
+                item = None
+
+            if item is not None:
+                # Map raw ActivityEvent dict -> wire schema (ECS by default).
+                try:
+                    mapped = self._mapper.map(item)
+                except Exception:  # noqa: BLE001
+                    _log.exception("forwarder: mapper failed; dropping event")
+                    self._dropped += 1
+                    mapped = None
+                if mapped is not None:
+                    batch.append(mapped)
+
+            should_flush = (
+                len(batch) >= self._batch_size
+                or (batch and (time.monotonic() - last_flush) >= self._flush_interval)
+                or (self._stop.is_set() and batch)
+            )
+            if should_flush:
+                self._flush(batch)
+                batch = []
+                last_flush = time.monotonic()
+
+    def _flush(self, batch: list[dict]) -> None:
+        try:
+            self._ship(batch)
+            self._sent += len(batch)
+        except Exception:  # noqa: BLE001
+            _log.exception(
+                "forwarder %s: shipping batch of %d events failed",
+                type(self).__name__,
+                len(batch),
+            )
+            self._dropped += len(batch)

--- a/aigis/forwarders/http_json.py
+++ b/aigis/forwarders/http_json.py
@@ -1,0 +1,161 @@
+"""Generic HTTPS / HTTP JSON forwarder.
+
+A minimal stdlib-only sink suitable for:
+
+* Splunk HTTP Event Collector (HEC) — point ``url`` at
+  ``https://<splunk>:8088/services/collector`` and set
+  ``Authorization: Splunk <token>`` in ``headers``,
+* Datadog Logs API (``https://http-intake.logs.datadoghq.com/api/v2/logs``),
+* Azure Sentinel via a custom Logs Ingestion endpoint (DCR-backed),
+* generic in-house SIEM ingest endpoints that accept newline-delimited JSON
+  or a JSON array body.
+
+For deployments that want a vendor-specific client (cosignature, regional
+endpoints, OAuth refresh) a thin subclass adds ~20 LOC; the base does the
+heavy lifting.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from typing import Literal
+
+from aigis.forwarders.base import LogForwarder
+
+_log = logging.getLogger("aigis.forwarders.http")
+
+# Conservative retry policy. SIEMs prefer steady drip over thundering retries.
+_DEFAULT_RETRIES = 2
+_DEFAULT_BACKOFF = 0.5  # seconds; doubled per attempt
+
+
+class HTTPJsonForwarder(LogForwarder):
+    """POST batched events as JSON to an HTTPS endpoint.
+
+    Parameters
+    ----------
+    url:
+        Full destination URL. HTTPS is recommended; the forwarder accepts
+        ``http://`` for in-VPC SIEM endpoints but logs a one-time warning.
+    headers:
+        Static headers (auth tokens, tenant IDs). Sensitive headers are
+        never logged.
+    body_format:
+        ``"ndjson"`` (default) writes one JSON object per line — the format
+        Splunk HEC's ``/event/raw`` and Elastic ``_bulk`` accept. ``"array"``
+        sends a single JSON list — what most generic SIEM ingest APIs want.
+    gzip_payload:
+        gzip-compress the request body. Recommended for high-volume sinks.
+    timeout:
+        Per-request timeout in seconds.
+    retries:
+        Number of retries on transport / 5xx errors before giving up the
+        batch. 4xx errors are not retried (they indicate misconfiguration
+        and the local JSONL tier still has the event).
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        body_format: Literal["ndjson", "array"] = "ndjson",
+        gzip_payload: bool = False,
+        timeout: float = 5.0,
+        retries: int = _DEFAULT_RETRIES,
+        backoff: float = _DEFAULT_BACKOFF,
+        **forwarder_kwargs: object,
+    ) -> None:
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"HTTPJsonForwarder url must be http(s); got {url!r}")
+        if url.startswith("http://"):
+            _log.warning(
+                "HTTPJsonForwarder: %s is not HTTPS; SIEM traffic is sensitive — "
+                "use TLS in production",
+                url,
+            )
+
+        self._url = url
+        self._headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "User-Agent": "aigis-forwarder/1",
+        }
+        if headers:
+            self._headers.update(headers)
+        if gzip_payload:
+            self._headers["Content-Encoding"] = "gzip"
+
+        self._body_format = body_format
+        self._gzip = gzip_payload
+        self._timeout = timeout
+        self._retries = max(0, retries)
+        self._backoff = max(0.0, backoff)
+
+        super().__init__(**forwarder_kwargs)  # type: ignore[arg-type]
+
+    # -- LogForwarder hook --------------------------------------------------
+
+    def _ship(self, batch: list[dict]) -> None:
+        if not batch:
+            return
+
+        body = self._encode(batch)
+        last_exc: Exception | None = None
+
+        for attempt in range(self._retries + 1):
+            try:
+                self._post(body)
+                return
+            except urllib.error.HTTPError as e:
+                # 4xx: don't retry — config bug. 5xx / network: retry.
+                if 400 <= e.code < 500:
+                    _log.error(
+                        "HTTPJsonForwarder: %s returned %d; not retrying. "
+                        "Events remain in local JSONL tier.",
+                        self._url,
+                        e.code,
+                    )
+                    raise
+                last_exc = e
+            except (urllib.error.URLError, TimeoutError, OSError) as e:
+                last_exc = e
+
+            if attempt < self._retries:
+                time.sleep(self._backoff * (2**attempt))
+
+        assert last_exc is not None
+        raise last_exc
+
+    # -- Internal -----------------------------------------------------------
+
+    def _encode(self, batch: list[dict]) -> bytes:
+        if self._body_format == "array":
+            payload = json.dumps(batch, ensure_ascii=False, default=str).encode("utf-8")
+        else:  # ndjson
+            buf = io.StringIO()
+            for doc in batch:
+                buf.write(json.dumps(doc, ensure_ascii=False, default=str))
+                buf.write("\n")
+            payload = buf.getvalue().encode("utf-8")
+
+        if self._gzip:
+            gz = io.BytesIO()
+            with gzip.GzipFile(fileobj=gz, mode="wb") as f:
+                f.write(payload)
+            payload = gz.getvalue()
+        return payload
+
+    def _post(self, body: bytes) -> None:
+        req = urllib.request.Request(  # noqa: S310 — URL is operator-supplied config
+            self._url, data=body, headers=self._headers, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+            # Drain the response so the connection can be reused / closed cleanly.
+            resp.read()

--- a/aigis/forwarders/schema/__init__.py
+++ b/aigis/forwarders/schema/__init__.py
@@ -1,0 +1,13 @@
+"""Wire-format mappers for forwarders.
+
+A mapper transforms a serialized :class:`aigis.activity.ActivityEvent` dict
+into the on-the-wire schema that a downstream system understands. The default
+:class:`ECSMapper` produces Elastic Common Schema 8.x — the de-facto lingua
+franca for Elastic, Sentinel (via the Log Ingestion API + DCR), Wazuh, and a
+growing number of OSS SIEMs. Additional mappers (CEF, OCSF, Splunk CIM) plug
+in here without touching the dispatch path.
+"""
+
+from aigis.forwarders.schema.ecs import ECSMapper, EventMapper
+
+__all__ = ["ECSMapper", "EventMapper"]

--- a/aigis/forwarders/schema/ecs.py
+++ b/aigis/forwarders/schema/ecs.py
@@ -1,0 +1,240 @@
+"""ActivityEvent -> Elastic Common Schema (ECS) 8.x mapper.
+
+ECS is chosen as the default wire format because:
+
+* it is the schema Elastic Security, Wazuh, and a number of OSS SIEMs natively
+  index without transform pipelines;
+* Microsoft Sentinel's Log Ingestion API + Data Collection Rules accept ECS
+  JSON directly via a simple KQL projection;
+* Splunk CIM can be derived from ECS field-by-field, so a CIM mapper is a
+  thin wrapper over this one when it is needed;
+* ECS field semantics (`event.action`, `event.outcome`, `event.severity`,
+  `user.name`, `process.command_line`) align cleanly with what
+  :class:`aigis.activity.ActivityEvent` already records.
+
+This mapper is intentionally pure-data: no I/O, no global state, deterministic
+output. That makes it trivial to golden-test and to swap behind
+:class:`EventMapper` for CEF / OCSF / custom schemas in later phases.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+# ECS version we target. We do not advertise a newer version than we have
+# actually validated against; downstream consumers use this for routing.
+ECS_VERSION = "8.11.0"
+
+# Map of Aigis policy decisions to ECS event.outcome values.
+# ECS only defines {success, failure, unknown}, so we map "deny" -> failure
+# (action was rejected), "allow" -> success, and "review" -> unknown
+# (decision deferred). The original Aigis decision is preserved verbatim
+# in aigis.policy.decision for analysts who need the precise label.
+_OUTCOME_MAP = {
+    "allow": "success",
+    "deny": "failure",
+    "review": "unknown",
+    "error": "failure",
+}
+
+# Map Aigis risk_level to ECS event.severity (1=info .. 7=critical, per ECS).
+_SEVERITY_MAP = {
+    "low": 2,
+    "medium": 4,
+    "high": 6,
+    "critical": 7,
+}
+
+
+@runtime_checkable
+class EventMapper(Protocol):
+    """Pluggable schema mapper.
+
+    Implementations transform the Aigis raw event dict into the wire-format
+    dict that the forwarder serializes (e.g. as JSON, CEF text, syslog
+    structured data).
+    """
+
+    def map(self, event: dict) -> dict:
+        """Return the mapped wire-format event. Must not mutate ``event``."""
+        ...
+
+
+class ECSMapper:
+    """Map an ActivityEvent dict to an ECS 8.x document.
+
+    Parameters
+    ----------
+    dataset:
+        Value for ``event.dataset``. Defaults to ``"aigis.activity"``; set
+        per-deployment if you need to split alerts from telemetry indexes.
+    service_name:
+        Value for ``service.name``. Defaults to ``"aigis"``.
+    namespace:
+        Optional value for ``data_stream.namespace`` — useful when shipping
+        to multi-tenant Elastic data streams.
+    """
+
+    def __init__(
+        self,
+        *,
+        dataset: str = "aigis.activity",
+        service_name: str = "aigis",
+        namespace: str | None = None,
+    ) -> None:
+        self._dataset = dataset
+        self._service_name = service_name
+        self._namespace = namespace
+
+    def map(self, event: dict) -> dict:
+        decision = event.get("policy_decision", "allow")
+        event_type = event.get("event_type", "tool_call")
+        risk_score = int(event.get("risk_score") or 0)
+        risk_level = event.get("risk_level") or "low"
+
+        # ECS event.kind: "alert" for blocked/reviewed/high-risk; "event"
+        # otherwise. Aligns with Elastic Security alert routing.
+        is_alert = (
+            decision in ("deny", "review")
+            or risk_score >= 50
+            or event_type in ("policy_block", "scan_alert")
+        )
+
+        doc: dict = {
+            "@timestamp": event.get("timestamp"),
+            "ecs": {"version": ECS_VERSION},
+            "event": {
+                "kind": "alert" if is_alert else "event",
+                "category": _ecs_category(event.get("action", "")),
+                "type": _ecs_event_type(event.get("action", "")),
+                "action": event.get("action"),
+                "outcome": _OUTCOME_MAP.get(decision, "unknown"),
+                "severity": _SEVERITY_MAP.get(risk_level, 2),
+                "dataset": self._dataset,
+                "module": "aigis",
+                "id": event.get("event_id") or None,
+                "risk_score": risk_score,
+                "reason": _join(event.get("remediation_hints")) or None,
+            },
+            "service": {
+                "name": self._service_name,
+                "type": "ai_agent_guard",
+            },
+            "user": {
+                "name": event.get("user_id") or None,
+            },
+            "host": {
+                # cwd is the project root — analysts treat it as the host
+                # working directory for the agent process.
+                "name": event.get("project_name") or None,
+            },
+            "process": {
+                "working_directory": event.get("cwd") or None,
+                # `target` may be a shell command, a file path, or a URL.
+                # Routing it to process.command_line gives Splunk CIM /
+                # Sentinel UEBA something to correlate against.
+                "command_line": event.get("target") or None,
+            },
+            "rule": {
+                "id": event.get("policy_rule_id") or None,
+                "ruleset": "aigis-policy",
+                "name": (event.get("matched_rules") or [None])[0],
+            },
+            "labels": {
+                "agent_type": event.get("agent_type") or None,
+                "session_id": event.get("session_id") or None,
+                "autonomy_level": event.get("autonomy_level") or None,
+                "memory_scope": event.get("memory_scope") or None,
+                "fix_applied": event.get("fix_applied"),
+            },
+            "aigis": {
+                # Preserve original semantics verbatim for analysts.
+                "schema_version": 1,
+                "event_type": event_type,
+                "policy": {
+                    "decision": decision,
+                    "rule_id": event.get("policy_rule_id") or None,
+                },
+                "risk": {
+                    "score": risk_score,
+                    "level": risk_level,
+                },
+                "matched_rules": list(event.get("matched_rules") or []),
+                "owasp_refs": list(event.get("owasp_refs") or []),
+                "remediation_hints": list(event.get("remediation_hints") or []),
+                "delegation_chain": list(event.get("delegation_chain") or []),
+                "estimated_cost_usd": event.get("estimated_cost"),
+                "suggested_fix": event.get("suggested_fix") or None,
+                "details": event.get("details") or {},
+            },
+        }
+
+        if self._namespace:
+            doc["data_stream"] = {
+                "type": "logs",
+                "dataset": self._dataset,
+                "namespace": self._namespace,
+            }
+
+        pruned = _prune(doc)
+        assert isinstance(pruned, dict)  # _prune of a dict is always a dict
+        return pruned
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# ECS event.category vocabulary — fixed enum upstream. We map Aigis action
+# prefixes onto the closest categories so dashboards work without custom KQL.
+_CATEGORY_BY_PREFIX = {
+    "shell": ["process"],
+    "file": ["file"],
+    "network": ["network"],
+    "llm": ["intrusion_detection"],
+    "mcp": ["intrusion_detection"],
+    "agent": ["process"],
+    "session": ["authentication"],
+    "scan": ["intrusion_detection"],
+    "policy": ["intrusion_detection"],
+}
+
+
+def _ecs_category(action: str) -> list[str]:
+    prefix = action.split(":", 1)[0] if ":" in action else action
+    return _CATEGORY_BY_PREFIX.get(prefix, ["process"])
+
+
+def _ecs_event_type(action: str) -> list[str]:
+    # ECS event.type is also an enum; we keep it conservative.
+    if action.startswith(("shell:", "agent:")):
+        return ["start"]
+    if action.startswith("file:write"):
+        return ["change"]
+    if action.startswith("file:read") or action.startswith("network:"):
+        return ["access"]
+    return ["info"]
+
+
+def _join(items: object) -> str | None:
+    if not items:
+        return None
+    if isinstance(items, list):
+        return " | ".join(str(x) for x in items if x)
+    return str(items)
+
+
+def _prune(value: object) -> object:
+    """Recursively drop None and empty-string values to keep ECS docs lean.
+
+    Empty lists and dicts are retained when they are the documented shape
+    (``aigis.matched_rules`` is a list whether or not it has entries) but
+    None/"" leaves are removed so SIEM mapping tables don't have to special-case
+    optional fields.
+    """
+    if isinstance(value, dict):
+        pruned = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in pruned.items() if v is not None and v != ""}
+    if isinstance(value, list):
+        return [_prune(x) for x in value]
+    return value

--- a/docs/forwarders.md
+++ b/docs/forwarders.md
@@ -1,0 +1,186 @@
+# SIEM forwarders
+
+> Mirror every Aigis event into Splunk, Elastic, Microsoft Sentinel, Datadog,
+> or any in-house ingest endpoint — without blocking agent execution and
+> without giving up the on-disk audit trail.
+
+## Why
+
+`ActivityStream` already writes three on-disk JSONL tiers (local / global /
+alerts) and `aigis.audit.SignedAuditLog` keeps an HMAC-chained tamper-evident
+log. Both are authoritative — but they live on the developer machine. For
+audit response, insider-threat analytics, or 24/7 보안관제, the events have
+to flow into the enterprise SOC's SIEM as well.
+
+Forwarders are a Tier-4 sink that sits *next to* the local tiers, not in
+place of them. If the SIEM goes down, the agent keeps running and the local
+JSONL is still complete.
+
+## Quick start — Splunk HEC
+
+```python
+from aigis.activity import ActivityStream
+from aigis.forwarders import HTTPJsonForwarder, ECSMapper
+
+stream = ActivityStream()
+stream.add_forwarder(
+    HTTPJsonForwarder(
+        url="https://splunk.internal:8088/services/collector",
+        headers={"Authorization": "Splunk <hec-token>"},
+        body_format="ndjson",
+        gzip_payload=True,
+        mapper=ECSMapper(dataset="aigis.activity"),
+    )
+)
+```
+
+That is the whole integration. Every subsequent `stream.record(event)` call
+(direct or via the Claude Code / Cursor adapters) is mirrored to Splunk on a
+background thread.
+
+## Quick start — Microsoft Sentinel
+
+Sentinel's Log Ingestion API accepts ECS JSON via a Data Collection Rule.
+Point the forwarder at the DCR endpoint and set the Bearer token from your
+managed identity:
+
+```python
+HTTPJsonForwarder(
+    url="https://<dce>.<region>-1.ingest.monitor.azure.com"
+        "/dataCollectionRules/<dcr-immutable-id>/streams/Custom-Aigis_CL?api-version=2023-01-01",
+    headers={"Authorization": f"Bearer {token}"},
+    body_format="array",
+    mapper=ECSMapper(dataset="aigis.activity", namespace="prod"),
+)
+```
+
+## Quick start — Elastic
+
+Elastic Common Schema is the default output, so a generic ingest pipeline
+works without transforms:
+
+```python
+HTTPJsonForwarder(
+    url="https://elastic.internal:9200/_bulk",
+    headers={"Authorization": "ApiKey <key>"},
+    body_format="ndjson",
+    mapper=ECSMapper(dataset="aigis.activity", namespace="prod"),
+)
+```
+
+## Redaction — required configuration step for compliance contexts
+
+**If your deployment is subject to PIPA, GDPR, APPI, or ISMS-P, a
+`Redactor` is a required configuration step, not optional.** The default
+mapper preserves analyst-facing fields verbatim — `aigis.matched_rules`,
+`aigis.details`, and the original `target` (which may be a shell command
+containing user input or PII). Forwarding those fields to a SIEM operated
+by a different data controller, or any SIEM at all in a regulated
+deployment, without redaction is the operator's PIPA / GDPR /
+APPI / ISMS-P incident.
+
+Minimum viable redactor:
+
+```python
+class _PipaPreset:
+    def redact(self, event: dict) -> dict:
+        event.pop("details", None)
+        event.pop("matched_rules", None)  # may contain rule sample text
+        return event
+
+stream.add_forwarder(
+    HTTPJsonForwarder(url=..., redactors=[_PipaPreset()])
+)
+```
+
+A richer example for defense-in-depth (mask home-directory paths in
+`target`, strip oversized fields):
+
+```python
+class StripDetails:
+    def redact(self, event: dict) -> dict:
+        event.pop("details", None)
+        if event.get("target", "").startswith("/home/"):
+            event["target"] = "<home-dir>"
+        return event
+
+HTTPJsonForwarder(
+    url=...,
+    redactors=[StripDetails()],
+)
+```
+
+Redactors run before the schema mapper, on the raw Aigis event dict — so you
+write rules against `aigis.activity.ActivityEvent` field names, not ECS
+paths. Pre-built jurisdiction-aware presets (KR PIPA, JP APPI) are a planned
+follow-up; until then, write the preset that matches your own data
+processing agreement.
+
+## Schema
+
+Default schema is **ECS 8.11.0**. The mapping preserves Aigis-native fields
+under `aigis.*` so analysts never lose information when correlating against
+upstream identity / network telemetry.
+
+| Aigis field | ECS field | Notes |
+|---|---|---|
+| `timestamp` | `@timestamp` | ISO-8601 UTC |
+| `action` (`shell:exec`, `file:read`, …) | `event.action`, `event.category` | Category derived from prefix |
+| `policy_decision` (`allow` / `deny` / `review`) | `event.outcome` (`success` / `failure` / `unknown`) | Original verb kept at `aigis.policy.decision` |
+| `risk_score` (0-100) | `event.risk_score` | Also exposed at `aigis.risk.score` |
+| `risk_level` (`low` / `medium` / `high` / `critical`) | `event.severity` (2 / 4 / 6 / 7) | |
+| `user_id` | `user.name` | |
+| `cwd` | `process.working_directory` | |
+| `target` | `process.command_line` | Single field; works for shell, file, URL targets |
+| `matched_rules[0]` | `rule.name` | Full list at `aigis.matched_rules` |
+| `policy_rule_id` | `rule.id` | |
+| Blocked / reviewed / risk ≥ 50 | `event.kind = "alert"` | Otherwise `event.kind = "event"` |
+
+Aigis-only fields (no ECS equivalent) live under `aigis.*`:
+`autonomy_level`, `delegation_chain`, `memory_scope`, `estimated_cost_usd`,
+`owasp_refs`, `remediation_hints`, `suggested_fix`, `fix_applied`, `details`.
+
+## Operational notes
+
+* **Non-blocking.** `HTTPJsonForwarder.submit()` enqueues onto a bounded
+  `queue.Queue` and returns immediately. Default queue size is 10,000 events
+  per forwarder; under saturation the oldest pending event is dropped (the
+  on-disk JSONL still has it).
+* **Counters.** `forwarder.stats` returns `{"sent": …, "dropped": …,
+  "queued": …}` — wire these into `/aig doctor` for visibility.
+* **Retry policy.** 5xx and network errors retry with exponential backoff
+  (default 2 retries). 4xx errors do not retry — they indicate
+  misconfiguration and noisy retries against a misconfigured endpoint
+  amplify the problem.
+* **TLS.** HTTPS is strongly recommended. HTTP works for in-VPC endpoints
+  but emits a one-time warning to the `aigis.forwarders.http` logger.
+* **Shutdown.** Call `stream.close_forwarders()` (or
+  `forwarder.close()`) on process exit to drain the queue. The worker is a
+  daemon thread, so abrupt exit will drop in-flight batches — these remain
+  in the on-disk JSONL.
+
+## Compliance mapping (한국 환경)
+
+The on-disk JSONL alone satisfies the *existence* of `audit log` controls.
+Forwarders close the *integration* gap that 감사관 / KISA / 금감원 검사관
+typically point at:
+
+| 통제항목 | 통합관제 갭이 메우는 부분 |
+|---|---|
+| ISMS-P 2.9 (로그관리) | "타 시스템 로그와 통합·상관분석" — 단일 SIEM 으로 흘려보내면 충족 |
+| ISMS-P 2.11 (이상행위 분석) | UEBA / 상관규칙은 SIEM 측에서 구동 — Aigis 는 신호원 |
+| 금융위 AI 가이드라인 (2024) "이상행위 탐지" | Aigis `risk_score ≥ 50` 이벤트가 `event.kind = "alert"` 로 SIEM 알람 파이프라인에 합류 |
+| PIPA 영 §30 (안전성 확보조치) 접속기록 보관 | `aigis.audit.SignedAuditLog` 무결성 chain + SIEM 사본의 이중화 |
+
+## Future transports
+
+The base class is intentionally minimal. Planned follow-ups (each ~50 LOC
+on top of `LogForwarder`):
+
+* `SyslogForwarder` — RFC 5424 over UDP / TCP / TLS (stdlib only).
+* `SplunkHECForwarder` — HEC-specific quirks (index, source, sourcetype,
+  channel ID for ack mode).
+* `SentinelForwarder` — DCR-aware client with managed-identity token
+  refresh (optional `azure-identity` extra).
+* `KafkaForwarder` — for environments that prefer log-bus → SIEM connector
+  decoupling (optional `confluent-kafka` extra).

--- a/docs/rfcs/0001-siem-forwarder.md
+++ b/docs/rfcs/0001-siem-forwarder.md
@@ -1,0 +1,247 @@
+# RFC 0001 — SIEM / log forwarder layer
+
+> Status: **Draft** · Author: @s1ns3nz0 · Phase 1 reference implementation
+> shipped on `feat/siem-forwarder` (this PR).
+
+## Summary
+
+Add a Tier-4 outbound sink — `aigis/forwarders/` — that mirrors every
+`ActivityEvent` to external SIEM / log-lake systems (Splunk HEC, Elastic,
+Microsoft Sentinel, Datadog, in-house ingest endpoints) without blocking
+the agent hot path and without changing the on-disk JSONL tiers.
+
+This lands the Phase 3 roadmap item
+[`ROADMAP.md`](../../ROADMAP.md) line 160 ("SIEM integration") as a vertical
+slice: foundation + ECS schema mapper + one universal transport (HTTPS
+JSON), all in stdlib-only Python so the zero-dep core is preserved.
+
+## Motivation
+
+`ActivityStream` (`aigis/activity.py`) already captures the right events
+with the right fields (`user_id`, `risk_score`, `policy_decision`,
+`matched_rules`, `owasp_refs`, `autonomy_level`, `delegation_chain`).
+`SignedAuditLog` (`aigis/audit/`) gives those events a tamper-evident chain.
+
+But until the events reach the enterprise SOC, several controls stay
+checked-in-letter-but-not-in-spirit:
+
+* **ISMS-P 2.9 / 2.11** require log management and 이상행위 분석 *in the
+  organisation's central monitoring stack* — local JSONL is not enough.
+* **금융위 AI 가이드라인 (2024)** treats LLM-side anomalies as a category
+  of 이상행위 탐지; they have to land in the same SOC pipe as everything
+  else.
+* **Insider-threat / UEBA** correlation needs Aigis signals next to IdP,
+  EDR, and DLP signals — that means the SIEM, not a developer's `~/.aigis/`.
+* **NIST SP 800-53 AU-2 / AU-6** ("audit events" / "audit review") implies
+  centralized review, not per-host log files.
+
+## Goals
+
+1. Add a clean extension point so anyone can plug in a forwarder for their
+   SIEM with ~50 LOC of subclass code.
+2. Ship a default ECS schema mapper that works for Elastic, Sentinel
+   (via DCR), Wazuh, and is straightforward to re-map to Splunk CIM.
+3. Preserve every Aigis-native field — `matched_rules`, `owasp_refs`,
+   `autonomy_level`, `delegation_chain`, `policy_decision` — verbatim so
+   analysts never lose information.
+4. Make it physically impossible for a misconfigured or down SIEM to
+   slow down, error out, or block an agent tool call.
+5. Zero new required dependencies. Transports that need third-party clients
+   (e.g. azure-identity for Sentinel managed-identity) go into extras.
+
+## Non-goals (this RFC)
+
+* Pre-built Splunk ES correlation rules or Sentinel analytic rules —
+  separate RFC, separate repo cadence.
+* Pre-built Sigma detection rule bundle — Phase 4 in the original plan.
+* Authentication-flow wrappers per vendor (OAuth refresh, IAM signing) —
+  ship as optional subclasses once Phase 1 is merged.
+
+## Design
+
+### Pipeline
+
+```
+ActivityStream.record(event)
+  ├─ Tier 1: local  JSONL  (unchanged, always)
+  ├─ Tier 2: global JSONL  (unchanged, if enabled)
+  ├─ Tier 3: alerts JSONL  (unchanged, if is_alert)
+  └─ Tier 4: for fwd in self._forwarders: fwd.submit(event)
+              └─ enqueue onto bounded background queue → worker thread
+                  └─ redact (in-memory dict, before mapping)
+                  └─ map   (ActivityEvent → ECS dict, default)
+                  └─ batch (size + interval thresholds)
+                  └─ ship  (HTTPS POST, with retry policy)
+```
+
+The dispatch order matters: the local JSONL tiers are written
+*synchronously* and *first*, so they remain authoritative even if the
+forwarder layer is misbehaving.
+
+### Class shape
+
+```python
+class LogForwarder(ABC):
+    def submit(self, event: ActivityEvent) -> None: ...     # never blocks, never raises
+    def close(self, timeout: float = 5.0) -> None: ...
+    @property
+    def stats(self) -> dict[str, int]: ...                  # sent / dropped / queued
+
+    @abstractmethod
+    def _ship(self, batch: list[dict]) -> None: ...         # subclass hook
+
+class EventMapper(Protocol):
+    def map(self, event: dict) -> dict: ...
+
+class Redactor(Protocol):
+    def redact(self, event: dict) -> dict: ...
+```
+
+* `Redactor` runs *before* the mapper, on the raw Aigis dict, so PIPA /
+  GDPR rules are written against the native field names.
+* `EventMapper` is a Protocol (not ABC) so adding CEF / OCSF / Splunk CIM
+  is a single file with no inheritance dance.
+
+### Schema — why ECS as default
+
+| Vendor / consumer | ECS support |
+|---|---|
+| Elastic / Wazuh | Native index pattern, no transform |
+| Microsoft Sentinel | Log Ingestion API + DCR consumes ECS JSON directly |
+| Splunk | One CIM transform per field (mappable from ECS) |
+| OSS SIEMs (SecurityOnion, OpenSearch SIEM) | Native |
+
+ECS is the only schema where the same `event.action` / `user.name` /
+`process.command_line` mapping works across the three biggest enterprise
+SIEMs. OCSF is gaining momentum (AWS Security Lake) but is not yet
+broadly consumed — recommended as a follow-up mapper, not the default.
+
+### Failure isolation
+
+| Failure mode | Behavior |
+|---|---|
+| SIEM unreachable | Worker retries 5xx with exponential backoff; on exhaustion the batch is dropped (still in local JSONL); counter incremented. |
+| SIEM returns 4xx | No retry (misconfig). Logged once per batch; counter incremented. |
+| Forwarder thread crashes | Caught at `record()` boundary; agent continues; logged. |
+| Queue full | Drop oldest pending event, enqueue newest; counter incremented. |
+| Mapper raises | Single event dropped; counter incremented; worker continues. |
+| Redactor raises | Single event dropped *before mapping*; counter incremented. |
+
+The invariant: **no forwarder failure mode can stop the agent or corrupt
+the on-disk JSONL.**
+
+### Compatibility
+
+* New code is fully opt-in. `ActivityStream._forwarders` defaults to `[]`
+  and `record()` skips Tier 4 entirely when the list is empty — the hot
+  path is unchanged for users who don't register a forwarder.
+* No new required dependencies. `pyproject.toml` is not modified by this
+  PR; vendor-specific subclasses will introduce extras in follow-up PRs.
+* No public API removed or renamed.
+
+## Reference implementation
+
+Phase 1 ships in this PR:
+
+```
+aigis/forwarders/
+├── __init__.py              # re-exports stable public symbols
+├── base.py                  # LogForwarder ABC, Redactor protocol, worker
+├── http_json.py             # generic HTTPS JSON sink (stdlib only)
+└── schema/
+    ├── __init__.py
+    └── ecs.py               # ActivityEvent → ECS 8.11.0
+
+aigis/activity.py            # +50 LOC: add_forwarder / remove_forwarder /
+                             #          close_forwarders + record() dispatch
+
+docs/forwarders.md           # quickstart (Splunk HEC / Sentinel / Elastic)
+docs/rfcs/0001-siem-forwarder.md  # this document
+
+tests/test_forwarders.py     # 14 new tests
+```
+
+**Tests: 1726 pass · 0 fail · 14 new in `test_forwarders.py`.**
+
+## Scope
+
+This PR is the **foundation slice only**. Per the discussion on
+[killertcell428/aigis#98](https://github.com/killertcell428/aigis/issues/98),
+the following items are explicitly *out of scope* and will each get their
+own follow-up issue once this lands:
+
+- Vendor-specific transports — `SyslogForwarder` (RFC 5424),
+  `SplunkHECForwarder`, `SentinelForwarder` (DCR-aware).
+- An OCSF mapper as a sibling of `ECSMapper`.
+- Durable on-disk queue spool (see Resolved decision #3 below).
+- Detection-content bundles — Sigma rules, Splunk ES / Sentinel analytic
+  rule sidecars.
+- KR-specific compliance presets (`compliance_kr.py` ISMS-P 2.9 / 2.11
+  status refresh, PIPA `Redactor` preset) — separate PR on the KR fork
+  after upstream lands.
+
+## Resolved design decisions
+
+Following the discussion on
+[killertcell428/aigis#98](https://github.com/killertcell428/aigis/issues/98):
+
+1. **Default schema → ECS 8.x.** Decision: ship ECS as the default mapper.
+   Keep the `EventMapper` Protocol seam so OCSF can be added as a sibling
+   mapper in a follow-up, *but do not ship the OCSF mapper in this PR*.
+   Rationale: ECS has the broadest installed consumer base across Splunk
+   (via CIM), Sentinel (via DCR), Elastic, and Wazuh — matching what JP/KR
+   enterprise SOCs are actually running today.
+
+2. **Module location → new `aigis/forwarders/` package.** Decision:
+   `aigis/middleware/` is reserved for LLM-provider request/response
+   proxies (Anthropic, OpenAI, LangChain, LangGraph, FastAPI), which is
+   semantically different from outbound log shipping. The maintainer will
+   update `CONTRIBUTING.md` to add a "log forwarders" section pointing at
+   the new package as part of the merge.
+
+3. **Queue persistence → defer to a follow-up issue.** Decision: ship the
+   foundation with the in-memory bounded queue only. Persisting the tail
+   across crashes (SQLite WAL spool, ~150 LOC) introduces an integrity
+   contract with the JSONL tier that warrants its own design, ideally
+   driven by an actual incident report ("we lost N events when the SIEM
+   was down for M hours").
+
+   > **TODO (follow-up issue):** durable on-disk spool for the forwarder
+   > queue. Open after the foundation lands and the first real outage
+   > tells us the loss model we are pricing.
+
+4. **PII redaction defaults → preserve fields; document Redactor as a
+   required configuration step.** Decision: keep the current
+   preserve-by-default behavior. Stripping `details` / rule sample text
+   silently would erase analyst signal, which is worse than a
+   documented-but-explicit configuration step. Future work: ship a
+   "KR PIPA preset" and a "JP APPI preset" `Redactor` in a follow-up.
+
+   For compliance contexts (PIPA, GDPR, APPI, ISMS-P) the `Redactor`
+   is **a required configuration step**, not optional. Operators of
+   those deployments must wire one before enabling the forwarder. The
+   minimum viable shape is:
+
+   ```python
+   class _PipaPreset:
+       def redact(self, event: dict) -> dict:
+           event.pop("details", None)
+           event.pop("matched_rules", None)  # may contain rule sample text
+           return event
+
+   stream.add_forwarder(
+       HTTPJsonForwarder(url=..., redactors=[_PipaPreset()])
+   )
+   ```
+
+   See `docs/forwarders.md` for the SOC-engineer-facing version.
+
+## Acceptance criteria
+
+* `uv run pytest` is green (currently 1726 pass).
+* `uv run ruff check aigis/forwarders/ tests/test_forwarders.py aigis/activity.py`
+  is clean.
+* New code adds no required dependencies (`pyproject.toml` unchanged).
+* `ActivityStream` with no forwarders registered behaves identically to
+  master (covered by the existing `tests/test_activity.py` suite, all 19
+  pre-existing tests still pass).

--- a/docs/rfcs/0001-siem-forwarder.md
+++ b/docs/rfcs/0001-siem-forwarder.md
@@ -206,9 +206,10 @@ Following the discussion on
    driven by an actual incident report ("we lost N events when the SIEM
    was down for M hours").
 
-   > **TODO (follow-up issue):** durable on-disk spool for the forwarder
-   > queue. Open after the foundation lands and the first real outage
-   > tells us the loss model we are pricing.
+   > **Follow-up:** [killertcell428/aigis#109](https://github.com/killertcell428/aigis/issues/109)
+   > — durable on-disk queue spool. Tracking issue stays open as a known
+   > design gap; active work begins when the first real outage gives us
+   > the loss model we are pricing.
 
 4. **PII redaction defaults → preserve fields; document Redactor as a
    required configuration step.** Decision: keep the current

--- a/tests/test_forwarders.py
+++ b/tests/test_forwarders.py
@@ -1,0 +1,497 @@
+"""Tests for aigis.forwarders.
+
+Coverage:
+  * ECS schema mapping (golden assertions on field structure & ECS enums)
+  * HTTPS round-trip against an in-process http.server-based fake collector
+  * Redactor protocol applied before mapping
+  * Bounded queue degrades gracefully under saturation
+  * ActivityStream.add_forwarder() wires events end-to-end without blocking
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from aigis.activity import ActivityEvent, ActivityStream
+from aigis.forwarders import (
+    ECSMapper,
+    HTTPJsonForwarder,
+    LogForwarder,
+)
+from aigis.forwarders.schema.ecs import ECS_VERSION
+
+# ---------------------------------------------------------------------------
+# Fake collector — minimal HTTP server we can introspect.
+# ---------------------------------------------------------------------------
+
+
+class _Collector:
+    """An in-process HTTP collector that records every request body."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self.fail_next_n = 0
+        self.status_override = 200
+
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_args: Any, **_kwargs: Any) -> None:  # silence
+                return
+
+            def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler API
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length)
+                if self.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.decompress(raw)
+                with collector._lock:
+                    collector.requests.append(
+                        {
+                            "path": self.path,
+                            "headers": dict(self.headers),
+                            "body": raw.decode("utf-8"),
+                        }
+                    )
+                    if collector.fail_next_n > 0:
+                        collector.fail_next_n -= 1
+                        self.send_response(503)
+                        self.end_headers()
+                        return
+                self.send_response(collector.status_override)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+        self._handler = Handler
+        self._server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self._server.server_port
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/ingest"
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def collector() -> Iterator[_Collector]:
+    c = _Collector()
+    try:
+        yield c
+    finally:
+        c.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# ECS mapper — golden tests
+# ---------------------------------------------------------------------------
+
+
+class TestECSMapper:
+    def test_alert_event_kind(self) -> None:
+        e = ActivityEvent(
+            action="shell:exec",
+            target="rm -rf /",
+            policy_decision="deny",
+            risk_score=95,
+            risk_level="critical",
+            matched_rules=["dangerous_commands"],
+            owasp_refs=["CWE-78"],
+            remediation_hints=["Use targeted deletion"],
+            policy_rule_id="P-001",
+            user_id="alice",
+        )
+        doc = ECSMapper().map(e.to_dict())
+
+        assert doc["ecs"]["version"] == ECS_VERSION
+        assert doc["event"]["kind"] == "alert"
+        assert doc["event"]["category"] == ["process"]
+        assert doc["event"]["outcome"] == "failure"
+        assert doc["event"]["severity"] == 7
+        assert doc["event"]["risk_score"] == 95
+        assert doc["event"]["action"] == "shell:exec"
+        assert doc["event"]["dataset"] == "aigis.activity"
+        assert doc["user"]["name"] == "alice"
+        assert doc["process"]["command_line"] == "rm -rf /"
+        assert doc["rule"]["name"] == "dangerous_commands"
+        assert doc["rule"]["id"] == "P-001"
+        # Aigis-native fields preserved verbatim
+        assert doc["aigis"]["policy"]["decision"] == "deny"
+        assert doc["aigis"]["matched_rules"] == ["dangerous_commands"]
+        assert doc["aigis"]["owasp_refs"] == ["CWE-78"]
+
+    def test_safe_event_kind(self) -> None:
+        e = ActivityEvent(action="file:read", target="readme.md", risk_score=0)
+        doc = ECSMapper().map(e.to_dict())
+        assert doc["event"]["kind"] == "event"
+        assert doc["event"]["outcome"] == "success"
+        assert doc["event"]["category"] == ["file"]
+
+    def test_review_outcome_is_unknown(self) -> None:
+        e = ActivityEvent(action="shell:exec", target="ls", policy_decision="review")
+        doc = ECSMapper().map(e.to_dict())
+        assert doc["event"]["outcome"] == "unknown"
+        assert doc["event"]["kind"] == "alert"
+
+    def test_namespace_emits_data_stream(self) -> None:
+        e = ActivityEvent(action="file:read", target="x")
+        doc = ECSMapper(namespace="tenant-a").map(e.to_dict())
+        assert doc["data_stream"] == {
+            "type": "logs",
+            "dataset": "aigis.activity",
+            "namespace": "tenant-a",
+        }
+
+    def test_none_fields_pruned(self) -> None:
+        e = ActivityEvent(action="file:read", target="x")
+        doc = ECSMapper().map(e.to_dict())
+        # user.name is unset (synthetic ActivityEvent fills user_id from OS,
+        # but it's never literally None). Confirm None pruning works by
+        # checking that an explicitly-empty optional is gone.
+        assert "reason" not in doc["event"]
+        assert "suggested_fix" not in doc["aigis"]
+
+    def test_outcome_error_maps_to_failure(self) -> None:
+        """ActivityEvent with policy_decision='error' (e.g. scan crash) must
+        surface as ECS event.outcome='failure' so SOC dashboards group it
+        with denies rather than dropping it as 'unknown'."""
+        e = ActivityEvent(action="shell:exec", target="ls", policy_decision="error")
+        doc = ECSMapper().map(e.to_dict())
+        assert doc["event"]["outcome"] == "failure"
+        # Original decision verb preserved verbatim for analysts who need
+        # to distinguish 'deny' (policy blocked) from 'error' (scan failed).
+        assert doc["aigis"]["policy"]["decision"] == "error"
+
+    def test_event_kind_alert_triggered_by_event_type(self) -> None:
+        """event.kind='alert' must be raised even when risk_score is low and
+        decision is allow, if event_type indicates a scan/block event."""
+        e = ActivityEvent(
+            action="scan:input",
+            target="x",
+            event_type="scan_alert",
+            risk_score=0,
+            policy_decision="allow",
+        )
+        doc = ECSMapper().map(e.to_dict())
+        assert doc["event"]["kind"] == "alert"
+
+
+# ---------------------------------------------------------------------------
+# HTTP forwarder — round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPJsonForwarder:
+    def test_ndjson_round_trip(self, collector: _Collector) -> None:
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            headers={"Authorization": "Bearer test"},
+            flush_interval=0.05,
+            batch_size=2,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="ls", user_id="alice"))
+            fwd.submit(ActivityEvent(action="file:read", target="x.py", user_id="alice"))
+            _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        assert len(collector.requests) >= 1
+        body = collector.requests[0]["body"].strip().splitlines()
+        docs = [json.loads(line) for line in body]
+        actions = {d["event"]["action"] for d in docs}
+        assert actions == {"shell:exec", "file:read"}
+        assert collector.requests[0]["headers"]["Authorization"] == "Bearer test"
+
+    def test_array_body_format(self, collector: _Collector) -> None:
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            body_format="array",
+            flush_interval=0.05,
+            batch_size=1,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="ls"))
+            _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        body = json.loads(collector.requests[0]["body"])
+        assert isinstance(body, list)
+        assert body[0]["event"]["action"] == "shell:exec"
+
+    def test_gzip_payload(self, collector: _Collector) -> None:
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            gzip_payload=True,
+            flush_interval=0.05,
+            batch_size=1,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="ls"))
+            _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        assert collector.requests[0]["headers"]["Content-Encoding"] == "gzip"
+        # Handler already decompressed for us; body should now be plain ndjson.
+        json.loads(collector.requests[0]["body"].strip().splitlines()[0])
+
+    def test_retry_on_5xx(self, collector: _Collector) -> None:
+        collector.fail_next_n = 2  # first two attempts return 503
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            flush_interval=0.05,
+            batch_size=1,
+            retries=3,
+            backoff=0.05,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="ls"))
+            _wait_for(lambda: fwd.stats["sent"] >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        # 2 failures + 1 success = 3 requests recorded
+        assert len(collector.requests) == 3
+        assert fwd.stats["sent"] == 1
+        assert fwd.stats["dropped"] == 0
+
+    def test_4xx_not_retried(self, collector: _Collector) -> None:
+        """4xx responses indicate misconfiguration; retrying amplifies the
+        bug and clutters the SIEM-side logs. The local JSONL tier already
+        has the event, so we drop and move on."""
+        collector.status_override = 401
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            flush_interval=0.05,
+            batch_size=1,
+            retries=3,  # would retry on 5xx, must not on 4xx
+            backoff=0.05,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="ls"))
+            _wait_for(lambda: fwd.stats["dropped"] >= 1, timeout=3.0)
+            # Give the worker enough time to attempt any (incorrect) retry
+            # so we can prove it did not happen.
+            time.sleep(0.5)
+        finally:
+            fwd.close()
+
+        assert len(collector.requests) == 1, (
+            f"4xx must not retry; got {len(collector.requests)} requests"
+        )
+        assert fwd.stats["sent"] == 0
+        assert fwd.stats["dropped"] >= 1
+
+    def test_rejects_non_http_url(self) -> None:
+        with pytest.raises(ValueError):
+            HTTPJsonForwarder("ftp://example.com/ingest")
+
+
+# ---------------------------------------------------------------------------
+# Redactor protocol
+# ---------------------------------------------------------------------------
+
+
+class _MaskTarget:
+    """Test redactor that masks the `target` field."""
+
+    def redact(self, event: dict) -> dict:
+        event["target"] = "<redacted>"
+        return event
+
+
+class _StripDetails:
+    def redact(self, event: dict) -> dict:
+        event.pop("details", None)
+        return event
+
+
+class TestRedactor:
+    def test_redactor_runs_before_mapping(self, collector: _Collector) -> None:
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            redactors=[_MaskTarget()],
+            flush_interval=0.05,
+            batch_size=1,
+        )
+        try:
+            fwd.submit(ActivityEvent(action="shell:exec", target="rm -rf /etc"))
+            _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        doc = json.loads(collector.requests[0]["body"].strip().splitlines()[0])
+        assert doc["process"]["command_line"] == "<redacted>"
+
+    def test_chained_redactors_apply_in_order(self, collector: _Collector) -> None:
+        """Multiple redactors run in registration order; each sees the
+        output of the previous one. Required to make compliance-preset
+        stacking (e.g. PIPA preset + project-specific overlay) predictable."""
+        fwd = HTTPJsonForwarder(
+            collector.url,
+            # First strips `details`, second masks `target`. After both run,
+            # the event should have neither `details` nor the original target.
+            redactors=[_StripDetails(), _MaskTarget()],
+            flush_interval=0.05,
+            batch_size=1,
+        )
+        try:
+            fwd.submit(
+                ActivityEvent(
+                    action="shell:exec",
+                    target="rm -rf /etc",
+                    details={"secret": "should-not-ship"},
+                )
+            )
+            _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+        finally:
+            fwd.close()
+
+        doc = json.loads(collector.requests[0]["body"].strip().splitlines()[0])
+        assert doc["process"]["command_line"] == "<redacted>"
+        # _StripDetails removed `details` from the raw event, so the
+        # mapped aigis.details should be the empty default `{}`.
+        assert doc["aigis"]["details"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Bounded queue: graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class _BlackHole(LogForwarder):
+    """Forwarder that never delivers — used to test queue overflow."""
+
+    def __init__(self) -> None:
+        self.shipped = 0
+        super().__init__(queue_size=4, batch_size=2, flush_interval=10.0)
+
+    def _ship(self, batch: list[dict]) -> None:
+        # Block long enough that the producer fills the queue.
+        time.sleep(60)
+
+
+class TestBoundedQueue:
+    def test_drops_oldest_when_full(self) -> None:
+        fwd = _BlackHole()
+        try:
+            for i in range(100):
+                fwd.submit(ActivityEvent(action="file:read", target=f"f{i}"))
+            # queue cap is 4, batch_size 2 -> worker may have drained ~2 into
+            # an in-flight batch before blocking. So queue + dropped should
+            # account for everything submitted minus what's in the worker.
+            assert fwd.stats["dropped"] > 0
+            assert fwd.stats["queued"] <= 4
+        finally:
+            fwd.close(timeout=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown — close() must flush pending events, not drop them
+# ---------------------------------------------------------------------------
+
+
+class _SyncCollector(LogForwarder):
+    """Forwarder that records ship() calls in-process — no HTTP server overhead
+    so close() drain timing is deterministic."""
+
+    def __init__(self, *, flush_interval: float = 60.0) -> None:
+        self.shipped: list[dict] = []
+        super().__init__(queue_size=100, batch_size=10, flush_interval=flush_interval)
+
+    def _ship(self, batch: list[dict]) -> None:
+        self.shipped.extend(batch)
+
+
+class TestForwarderShutdown:
+    def test_close_flushes_pending_batch(self) -> None:
+        """close() must drain the queue and ship in-flight batches.
+        Without this guarantee, a graceful agent shutdown silently loses
+        the last seconds of audit signal — exactly when an incident is
+        most likely to be unfolding."""
+        # flush_interval is huge (60s) so the worker would NEVER flush on
+        # its own within the test timeout. Only close() can drain it.
+        fwd = _SyncCollector(flush_interval=60.0)
+        for i in range(3):
+            fwd.submit(ActivityEvent(action="file:read", target=f"f{i}"))
+
+        # Nothing shipped yet — batch_size 10 not reached, interval not hit.
+        assert fwd.shipped == []
+
+        fwd.close(timeout=2.0)
+
+        # close() must have drained all 3 events.
+        assert len(fwd.shipped) == 3
+        actions = {e.get("event", {}).get("action") for e in fwd.shipped}
+        assert actions == {"file:read"}
+
+
+# ---------------------------------------------------------------------------
+# ActivityStream integration
+# ---------------------------------------------------------------------------
+
+
+class TestActivityStreamForwarderIntegration:
+    def test_event_reaches_forwarder(self, collector: _Collector) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stream = ActivityStream(log_dir=tmpdir, enable_global=False, enable_alerts=False)
+            fwd = HTTPJsonForwarder(collector.url, flush_interval=0.05, batch_size=1)
+            stream.add_forwarder(fwd)
+            try:
+                stream.record(ActivityEvent(action="shell:exec", target="ls"))
+                _wait_for(lambda: len(collector.requests) >= 1, timeout=3.0)
+            finally:
+                stream.close_forwarders(timeout=1.0)
+
+            # Local JSONL tier still written
+            events = stream.query(days=1)
+            assert len(events) == 1
+            # Forwarder also delivered
+            doc = json.loads(collector.requests[0]["body"].strip().splitlines()[0])
+            assert doc["event"]["action"] == "shell:exec"
+
+    def test_broken_forwarder_does_not_block_record(self) -> None:
+        class Boom:
+            def submit(self, _event: object) -> None:
+                raise RuntimeError("siem on fire")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stream = ActivityStream(log_dir=tmpdir, enable_global=False, enable_alerts=False)
+            stream._forwarders.append(Boom())  # type: ignore[arg-type]
+            # Must not raise even though the forwarder explodes
+            stream.record(ActivityEvent(action="shell:exec", target="ls"))
+            assert len(stream.query(days=1)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for(predicate: Any, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for {predicate}")
+
+
+# Used only to satisfy mypy/ruff for the silently-imported io
+_ = io


### PR DESCRIPTION
## Summary

Foundation slice for the Phase 3 ROADMAP SIEM integration item, agreed in
the design discussion at #98. Adds `aigis/forwarders/` — a Tier-4 outbound
sink that mirrors `ActivityEvent`s into external SIEMs (Splunk HEC,
Elastic, Sentinel via DCR, Datadog, in-house ingest) without blocking the
agent hot path and without changing the on-disk JSONL tiers.

Stdlib-only — `pyproject.toml` untouched.

## Maintainer decisions from #98 — how this PR addresses each

| # | Decision (#98) | This PR |
|---|---|---|
| 1 | ECS 8.x as default; OCSF as future sibling; do not ship OCSF here | `ECSMapper` ships as default; `EventMapper` Protocol seam preserved; no OCSF mapper in this PR |
| 2 | New `aigis/forwarders/` package; `middleware/` reserved for LLM-provider proxies | New top-level package, no `middleware/` overlap |
| 3 | Queue persistence — defer to follow-up issue; add TODO + paragraph in RFC | RFC carries the TODO pointer at "Resolved design decisions" #3 (see open question below on when to file the follow-up issue) |
| 4 | PII redaction — preserve by default; document Redactor as required step with one-line sample | `docs/forwarders.md` "Redaction — required configuration step" + RFC compliance note + one-line `_PipaPreset` sample |

## Maintainer-listed required test coverage — what asserts each invariant

| Required (#98) | Test |
|---|---|
| Forwarder exception does not propagate to `record()` | `TestActivityStreamForwarderIntegration::test_broken_forwarder_does_not_block_record` |
| Bounded queue drops oldest on overflow + ops counter exposed | `TestBoundedQueue::test_drops_oldest_when_full` + `LogForwarder.stats` |
| ECS mapping preserves all Aigis-native fields under `aigis.*` | `TestECSMapper::test_alert_event_kind` asserts `aigis.policy.decision`, `aigis.matched_rules`, `aigis.owasp_refs` |
| `HTTPJsonForwarder` retries 5xx but not 4xx | `test_retry_on_5xx` + `test_4xx_not_retried` |
| gzip path round-trips | `test_gzip_payload` |

Plus four extra tests beyond the maintainer-listed minimum, to lock in
behavior that documentation promises:

| Extra invariant | Test |
|---|---|
| `policy_decision="error"` → `event.outcome="failure"` (not silently "unknown") | `test_outcome_error_maps_to_failure` |
| `event.kind="alert"` raised by `event_type` even when risk_score is 0 | `test_event_kind_alert_triggered_by_event_type` |
| Chained `Redactor`s apply in registration order (preset-stacking predictability) | `test_chained_redactors_apply_in_order` |
| `close()` drains pending batch (no silent loss on graceful shutdown) | `TestForwarderShutdown::test_close_flushes_pending_batch` |

## Hard invariants verified

- `ActivityStream` with no forwarder registered behaves identically to
  master (existing `tests/test_activity.py` suite — 19 tests — untouched
  and green).
- Zero new required dependencies (`pyproject.toml` unchanged).
- A misconfigured or down SIEM cannot stop the agent or corrupt JSONL.

## Quality gates

- `uv run pytest --tb=no -q` → **1692 passed · 0 failed**
  (upstream baseline 1673 + 19 new in `test_forwarders.py`)
- `uv run ruff check aigis/ tests/` → All checks passed
- `uv run ruff format --check aigis/ tests/` → 154 files already formatted
- `uv run mypy aigis/` (strict, 95 source files) → no issues
- Module coverage (`pytest --cov=aigis/forwarders`) → **90% TOTAL**
  (ecs.py 96%, http_json.py 93%, base.py 84% — uncovered lines in
  base.py are worker-loop timeout/sentinel edges that are exercised
  indirectly by the integration tests but not pinned by direct asserts)

## Out of scope (follow-up issues)

Per #98:
- Vendor-specific transports (`SyslogForwarder`, `SplunkHECForwarder`,
  `SentinelForwarder`).
- OCSF mapper.
- Durable on-disk queue spool (RFC carries the TODO; ideally driven by
  a real outage incident report so we can price the loss model).
- Detection-content bundles (Sigma, Splunk ES, Sentinel analytic rules).
- KR-specific compliance updates (`compliance_kr.py` ISMS-P 2.9 / 2.11
  status refresh, PIPA `Redactor` preset) — separate PR on the KR fork
  after this lands.

## Three things I want your call on before merge

1. **Class naming — settled on `HTTPJsonForwarder` (was `HttpJsonForwarder`
   in the reference impl).** Switching to all-caps for short acronyms keeps
   the class consistent with `ECSMapper` and matches the upstream codebase
   convention I observed (`MCPToolSnapshot`, `MCPServerReport`,
   `MCPDiffResult`, `MCPStageFinding`, `AIGuardianMiddleware`,
   `AIGuardianCallback`). Your reply on #98 wrote `EcsMapper`, which may
   have been a transcription nuance from the AI-assisted drafting you
   mentioned — I went with all-caps because it matches the rest of the
   codebase. Happy to swap both to `EcsMapper` / `HttpJsonForwarder` if
   the title-case form is your actual preference. Trivial amend either way.

2. **Queue-persistence follow-up issue — open it now or after merge?** Your
   #98 reply asked for "a `TODO:` and a short paragraph pointing at that
   follow-up issue." The RFC currently has the TODO + paragraph in place
   but no issue number to link, because opening a "queue persistence"
   issue before the foundation exists felt like the cart before the horse.
   Two reasonable paths:
   - (a) Open the follow-up issue now; I add the issue number to the RFC
     in this PR via a small follow-up commit.
   - (b) Land this PR as-is; the issue gets opened post-merge with the
     loss-model context that the first real outage gives us.

   Defaulting to (b); flag if you'd rather have (a).

3. **CHANGELOG entry under `## [Unreleased]`.** The CHANGELOG header notes
   that "entries below `## [Unreleased]` are appended automatically by the
   auto-improvement loop." I added a manual entry there because that is
   where Keep-a-Changelog convention says new work goes, but I want to
   flag the possibility that this overlaps your auto-improvement loop's
   write path. If you have a separate convention for human-authored
   foundation work (e.g. land in `### Added` per release rather than in
   Unreleased), I'm happy to move the entry; just point me at the
   intended pattern.

## Refs

- Design discussion: #98
- RFC: [`docs/rfcs/0001-siem-forwarder.md`](docs/rfcs/0001-siem-forwarder.md)
- ROADMAP item linked to this PR by #101: [ROADMAP.md Phase 3 SIEM](https://github.com/killertcell428/aigis/blob/master/ROADMAP.md)
- Reference branch (read-only artifact from the #98 discussion):
  <https://github.com/s1ns3nz0/aigis-kr/pull/1>

Closes the foundation portion of #98. Vendor transports, OCSF, and the
queue spool will land in their own follow-up PRs.

---

DCO sign-off included in the commit; commit message body mirrors this PR
description for git-only readers.
