### PR TITLE
fix(build): pin hatchling<1.30 to keep Metadata-Version at 2.4 for twine check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27,<1.30"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Summary
- `Build package` ジョブが `twine check dist/*` で `InvalidDistribution: '2.5' is not a valid metadata version` と落ちる
- 原因: `hatchling 1.30.0` (PyPI, 2026 / PEP 794) が wheel の `Metadata-Version` を 2.5 にバンプ。`twine 6.2.0` (PyPI 現行最新) はまだ 2.5 を受け付けず、`packaging` 経由で `InvalidDistribution` を投げる
- 修正: `[build-system].requires` を `hatchling>=1.27,<1.30` に固定し、emitted Metadata-Version を 2.4 に戻す。twine 側の 2.5 対応が降りてきたら上限ピンを外す

## Failing run reference
- master CI: [run 26730906613](https://github.com/killertcell428/aigis/actions/runs/26730906613) (job `Build package`)
- 同一エラーで失敗中の dependabot PR: `actions/checkout 6.0.2 (#107)` 以降の master push および各種 dependabot ブランチ
- twine 側の 2.5 対応は未リリース（[changelog](https://twine.readthedocs.io/en/stable/changelog.html) に 2.5 言及なし）

## Test plan
- [x] `rm -rf dist && python -m build` → `pyaigis-1.1.8-py3-none-any.whl` & sdist 生成
- [x] `unzip -p dist/pyaigis-1.1.8-py3-none-any.whl '*/METADATA' | head -3` → `Metadata-Version: 2.4`
- [x] `twine check dist/*` → 両 artifact `PASSED`
- [ ] CI の `Build package` ジョブが緑になることを確認
- [ ] `release.yml` 側も同じ build backend を経由するため、次の `release: vX.Y.Z` で副次回帰がないこと

## Follow-up
- twine が Metadata-Version 2.5 を受け入れた段階で `<1.30` の上限を外し、`hatchling` を最新に追従させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)