### PR TITLE
launch: publish Zenn article (claude-code-it-approval-oss)

### DIFF
--- a/articles/claude-code-it-approval-oss.md
+++ b/articles/claude-code-it-approval-oss.md
@@ -3,7 +3,7 @@ title: "Claude Code、会社で使う許可が下りない — 情シスが「�
 emoji: "🛡️"
 type: "tech"
 topics: ["claudecode", "セキュリティ", "AIエージェント", "OSS", "情シス"]
-published: false
+published: true
 ---
 
 ## 「とりあえず個人の判断で使ってください」では済まない


### PR DESCRIPTION
Flips `articles/claude-code-it-approval-oss.md` to `published: true` so the trust-layer launch article goes live on Zenn (and auto-syncs to Qiita via `sync-zenn-qiita.yml`) on merge.

This is the launch announcement anchor for the repositioning landed in #128. One-line frontmatter change; no code.

Requested explicitly by the maintainer ("確認したのでローンチをお願いします") after reviewing the content and merging #128.

https://claude.ai/code/session_01QnaesdjypqP5CqQbUKJ2su

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnaesdjypqP5CqQbUKJ2su)_