### PR TITLE
docs: align MITRE_ATLAS_COVERAGE.md to current official ATLAS IDs (closes #166)

### DIFF
--- a/docs/compliance/MITRE_ATLAS_COVERAGE.md
+++ b/docs/compliance/MITRE_ATLAS_COVERAGE.md
@@ -1,32 +1,46 @@
 # Aigis — MITRE ATLAS Coverage Matrix
 
-> Last updated: 2026-04-10
-> Aigis version: v1.3.1
-> Reference: [MITRE ATLAS v5.4.0](https://atlas.mitre.org/)
+> Last updated: 2026-07-08
+> Aigis version: v1.1.11
+> Reference: [MITRE ATLAS](https://atlas.mitre.org/) (current matrix)
+> Companion: [ATR_CROSSWALK.md](./ATR_CROSSWALK.md)
 
 ## Overview
 
-MITRE ATLAS (Adversarial Threat Landscape for AI Systems) catalogs adversarial tactics and techniques against AI systems. This document maps Aigis's 121 detection patterns to relevant ATLAS techniques, demonstrating coverage of real-world AI attack vectors.
+MITRE ATLAS (Adversarial Threat Landscape for AI Systems) catalogs adversarial
+tactics and techniques against AI systems. This document maps Aigis detection
+patterns to current official ATLAS technique IDs.
+
+> **Note on prior version:** The previous revision of this document used an
+> older, non-standard numbering scheme (e.g. AML.T0057 was labelled "LLM Plugin
+> Compromise"; AML.T0066–T0072 were introduced as custom identifiers not present
+> in the official ATLAS matrix). This revision aligns all IDs to the current
+> official ATLAS matrix. See [ATR_CROSSWALK.md](./ATR_CROSSWALK.md) for the
+> verified crosswalk that surfaced the drift.
+
+---
 
 ## Coverage Summary
 
-| ATLAS Tactic | Techniques | Aigis Coverage |
-|-------------|:----------:|:--------------------:|
-| Reconnaissance | 8 | Pre-interaction (2/8) — Attacker reconnaissance occurs before LLM execution |
-| Resource Development | 5 | Pre-interaction (0/5) — Attack infrastructure development is an external activity |
-| Initial Access | 9 | **Full coverage (7/9)** — Remaining 2 fall within infrastructure authentication |
-| ML Model Access | 5 | Infrastructure (2/5) — Model authentication/authorization is infrastructure-level control |
-| Execution | 5 | **Full coverage (4/5)** — Remaining 1 falls within OS execution environment |
-| Persistence | 3 | Infrastructure (1/3) — OS/cache-level persistence |
-| Privilege Escalation | 2 | **Full (2/2)** |
-| Defense Evasion | 8 | **Full coverage (5/8)** — Remaining 3 are model-internal evasion techniques |
-| Credential Access | 3 | **Full (3/3)** |
-| Discovery | 5 | Behavioral (2/5) — Requires behavioral analysis |
-| Collection | 4 | **Full coverage (3/4)** |
-| Exfiltration | 4 | **Full (4/4)** |
-| Impact | 6 | **Full coverage (4/6)** — Remaining 2 require real-world impact assessment |
+| ATLAS Tactic | Covered techniques |
+|---|---|
+| Initial Access | AML.T0051, AML.T0051.001, AML.T0054, AML.T0056 |
+| Execution | AML.T0053, AML.T0050 |
+| Persistence | AML.T0080 |
+| Defense Evasion | AML.T0054 (jailbreak bypass), normalisation layer |
+| Credential Access | AML.T0056, AML.T0057 |
+| Lateral Movement | AML.T0070 |
+| Collection | AML.T0024, AML.T0025 |
+| Exfiltration | AML.T0024, AML.T0025, AML.T0057 |
+| Impact | AML.T0029, AML.T0105 |
+| Supply Chain | AML.T0010, AML.T0109, AML.T0110 |
 
-**Full coverage of all runtime-detectable techniques (40/67). The 27 uncovered items are activities such as reconnaissance, resource development, and infrastructure control that occur before or outside LLM execution, and are outside the scope of input/output scanning tools.**
+**Runtime-detectable techniques with Aigis coverage: 15 confirmed (see
+[ATR_CROSSWALK.md](./ATR_CROSSWALK.md) §crosswalk for the verified table).**
+
+Techniques not covered by Aigis are either (a) training-time / model-artifact /
+infrastructure techniques that fall outside input/output scanning, or (b) runtime
+gaps documented in ATR_CROSSWALK.md §gap-analysis-b.
 
 ---
 
@@ -35,89 +49,75 @@ MITRE ATLAS (Adversarial Threat Landscape for AI Systems) catalogs adversarial t
 ### Initial Access
 
 | ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0051 | LLM Prompt Injection — Direct | **Full** | 18 prompt injection patterns (EN/JA/KO/ZH) + 6 jailbreak patterns + similarity detection |
-| AML.T0051.001 | LLM Prompt Injection — Stored/Indirect | **Full** | 5 indirect injection patterns (`ii_*`) + `scan_rag_context()` API |
+|---|---|:---:|---|
+| AML.T0051 | LLM Prompt Injection | **Full** | `pi_ignore_instructions`, `pi_new_instructions`, `pi_role_switch` (EN/JA/KO/ZH), `pi_jailbreak_dan`, similarity detection |
+| AML.T0051.001 | LLM Prompt Injection: Indirect | **Full** | `ii_context_poisoning`, `ii_hidden_instruction`, `ii_invisible_text`, `ii_tool_abuse` + `scan_rag_context()` API |
 | AML.T0054 | LLM Jailbreak | **Full** | `jb_evil_roleplay`, `jb_no_restrictions`, `jb_fictional_bypass`, `jb_grandma_exploit`, `jb_developer_mode`, `jb_ignore_ethics` |
-| AML.T0056 | LLM Prompt Injection via RAG Data Poisoning | **Full** | `ii_context_poisoning`, `ii_hidden_instruction`, `ii_invisible_text` + RAG scanning API |
-| AML.T0043 | Adversarial Data in Training | Partial | Indirect detection via content scanning patterns |
-| AML.T0052 | Phishing | Partial | Data exfiltration patterns detect phishing-related content |
-| AML.T0057 | LLM Plugin Compromise | **Detected** | `ii_tool_abuse` detects tool/function call manipulation |
+| AML.T0056 | Extract LLM System Prompt | **Full** | `pi_system_prompt_leak`, `pl_repeat_back_verbatim`, `pl_*` prompt-leak family (4 languages) |
 
 ### Execution
 
 | ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0053 | Command and Control via LLM | **Full** | `cmdi_shell`, `cmdi_path_traversal`, `exfil_send_to_external` |
-| AML.T0055 | Unsafe LLM Output Handling | **Full** | 7 output patterns including `out_harmful_instructions`, `out_secret_leak` |
-| AML.T0058 | LLM Tool Misuse | **Full** | `ii_tool_abuse` + data exfiltration patterns |
-| AML.T0059 | LLM-Assisted Code Execution | **Detected** | `cmdi_shell` detects shell command injection attempts |
+|---|---|:---:|---|
+| AML.T0053 | AI Agent Tool Invocation | **Full** | `ii_tool_abuse` detects manipulated or unauthorised tool/function calls |
+| AML.T0050 | Command and Scripting Interpreter | **Full** | `cmdi_shell`, `cmdi_path_traversal` |
 
-### Privilege Escalation
+### Persistence
 
 | ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0060 | LLM Privilege Escalation via Prompt | **Full** | `pi_role_switch` (4 languages), `jb_developer_mode`, `pi_system_prompt_leak` |
-| AML.T0061 | LLM Guardrail Bypass | **Full** | `pi_encoding_bypass`, `jb_no_restrictions`, `jb_ignore_ethics`, restriction bypass patterns (JA/KO/ZH) |
+|---|---|:---:|---|
+| AML.T0080 | AI Agent Context Poisoning | **Full** | `mem_cross_session_persistence`, `mem_experience_hijack` |
 
-### Defense Evasion
-
-| ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0015 | Evade ML Model — Adversarial Example | **Mitigated** | NFKC normalization, zero-width character removal, fullwidth→halfwidth conversion |
-| AML.T0062 | LLM Prompt Obfuscation | **Full** | `pi_encoding_bypass` + text normalization layer |
-| AML.T0063 | Token Manipulation | **Full** | `te_unicode_noise`, `te_null_byte_stuffing`, NFKC normalization |
-| AML.T0064 | LLM Prompt Splitting | **Detected** | Similarity detection catches split/paraphrased attacks via sliding window |
-| AML.T0065 | Context Window Overflow | **Full** | `te_repetition_flood_en`, `te_repetition_flood_ja`, `te_ignore_prefix_buried`, heuristic detection |
-
-### Credential Access
+### Collection / Exfiltration
 
 | ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0024 | Exfiltration via Cyber Means | **Full** | `exfil_send_to_external`, `exfil_keyword`, `ii_exfil_via_markdown` |
-| AML.T0066 | LLM System Prompt Theft | **Full** | 12 prompt leak patterns (`pl_*`, `pi_*_system_prompt`) across 4 languages |
-| AML.T0067 | LLM Credential Extraction | **Full** | `pii_api_key_input`, `conf_password_literal`, `conf_connection_string`, `out_secret_leak` |
-
-### Collection
-
-| ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0025 | Exfiltration via ML Inference API | **Detected** | `exfil_api_keys`, `exfil_pii_request` |
-| AML.T0035 | ML Artifact Collection | Partial | `conf_internal_doc` detects internal document markers |
-| AML.T0068 | LLM Data Leakage | **Full** | 17 PII input patterns + 5 PII output patterns + 4 data exfiltration patterns |
-
-### Exfiltration
-
-| ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0024 | Exfiltration via Cyber Means | **Full** | `exfil_send_to_external`, `exfil_keyword` |
-| AML.T0069 | LLM Data Exfil via Output | **Full** | `out_pii_ssn`, `out_pii_credit_card`, `out_pii_email_bulk`, `out_secret_leak` |
-| AML.T0070 | LLM Exfil via Embedded Links | **Full** | `ii_exfil_via_markdown` (markdown image + HTML img with query params) |
-| AML.T0071 | LLM Exfil via Tool Calls | **Full** | `ii_tool_abuse` detects tool/function call manipulation for data exfil |
+|---|---|:---:|---|
+| AML.T0057 | LLM Data Leakage | **Full** | `out_secret_leak`, `out_pii_ssn`, `out_pii_credit_card`, `out_pii_email_bulk`, `exfil_api_keys`, 17 PII input patterns |
+| AML.T0024 | Exfiltration via AI Inference API | **Full** | `exfil_send_to_external`, `exfil_api_keys`, `exfil_pii_request` |
+| AML.T0025 | Exfiltration via Cyber Means | **Full** | `ii_exfil_via_markdown` (markdown image beacon / HTML img), `exfil_send_to_external` |
+| AML.T0070 | RAG Poisoning | **Full** | `ii_context_poisoning` + `scan_rag_context()` API |
 
 ### Impact
 
 | ATLAS ID | Technique | Aigis Coverage | Patterns |
-|----------|-----------|:-------------------:|----------|
-| AML.T0029 | Denial of ML Service | **Full** | 5 token exhaustion patterns + heuristic |
-| AML.T0048 | External Harms — Financial | **Detected** | Financial PII patterns (credit card, bank account, SSN) |
-| AML.T0049 | External Harms — Reputational | **Detected** | `out_harmful_instructions` prevents harmful content generation |
-| AML.T0072 | LLM Harmful Content Generation | **Full** | `out_harmful_instructions` + jailbreak prevention (6 patterns) |
+|---|---|:---:|---|
+| AML.T0029 | Denial of ML Service | **Full** | `te_repetition_flood_en`, `te_repetition_flood_ja`, `te_ignore_prefix_buried`, token exhaustion heuristic |
+| AML.T0105 | Escape to Host | **Full** | `se_container_escape`, `afe_python_mro_escape` |
+
+### Supply Chain
+
+| ATLAS ID | Technique | Aigis Coverage | Patterns |
+|---|---|:---:|---|
+| AML.T0010 | AI Supply Chain Compromise | **Full** | `sc_compromised_pkg_version` |
+| AML.T0110 | AI Agent Tool Poisoning | **Full** | `mcp_cross_tool_shadow` and `mcp_*` scanner family |
+| AML.T0109 | AI Supply Chain Rug Pull | **Full** | `mcp_rug_pull_indicator` |
 
 ---
 
-## Agentic AI Threat Coverage
+## Runtime Gaps (no Aigis pattern yet)
 
-MITRE ATLAS v5.4.0 introduced techniques specific to autonomous AI agents. Aigis's coverage:
+These ATLAS techniques are runtime-detectable in principle but Aigis has no
+pattern for them today. Contributed patterns welcome.
 
-| Agentic Threat | Aigis Mitigation |
-|---------------|----------------------|
-| Agent prompt injection via tools | `ii_tool_abuse` pattern |
-| Agent data exfiltration | `exfil_*` + `ii_exfil_via_markdown` patterns |
-| Agent privilege escalation | `pi_role_switch` + `jb_developer_mode` |
-| Agent instruction override | `pi_ignore_instructions` (4 languages) |
-| RAG poisoning of agent context | `scan_rag_context()` API + `ii_*` patterns |
-| Multi-agent coordination attacks | LangGraph `GuardNode` integration |
+| ATLAS ID | Technique | Why detectable | Gap filed |
+|---|---|---|---|
+| AML.T0069 | Discover LLM System Information | Recon prompts enumerating tool schemas are screenable input patterns | [#166](https://github.com/killertcell428/aigis/issues/166) |
+| AML.T0060 | Publish Hallucinated Entities | Hallucinated package names in output, matchable against a package-name heuristic | — |
+| AML.T0102 | Generate Malicious Commands | Output-side generation of harmful command strings | — |
+| AML.T0104 | Publish Poisoned AI Agent Tool | Malicious tool/skill manifest, screenable in `mcp_scanner` | — |
+| AML.T0034 | Cost Harvesting | Token/compute exhaustion for cost damage; related to `te_*` DoS family | — |
+
+---
+
+## Out-of-scope techniques
+
+The following ATLAS techniques concern training data, model artifacts, model
+access, or pre-interaction infrastructure. They are correctly outside Aigis's
+input/output scanning scope.
+
+AML.T0011, AML.T0018, AML.T0019, AML.T0020, AML.T0036, AML.T0040,
+AML.T0043, AML.T0044, AML.T0046, AML.T0047, AML.T0048, AML.T0049,
+AML.T0052, AML.T0055.
 
 ---
 
@@ -126,29 +126,32 @@ MITRE ATLAS v5.4.0 introduced techniques specific to autonomous AI agents. Aigis
 ```
 ATLAS Kill Chain Stage          Aigis Defense Layer
 ──────────────────────────────────────────────────────────
-Reconnaissance                  [Out of Scope] Attacker reconnaissance (pre-LLM execution)
-Resource Development            [Out of Scope] Attack infrastructure development (external activity)
-Initial Access                  ██████████ 112 input patterns (detects all runtime attacks)
-ML Model Access                 [Out of Scope] Model authentication/authorization (infrastructure control)
-Execution                       ██████████ Command injection + output filter
-Persistence                     ██████████ Memory poisoning + context contamination detection
-Privilege Escalation            ██████████ Role switching + second-order injection detection
-Defense Evasion                 ██████████ NFKC normalization + obfuscation bypass detection
-Credential Access               ██████████ PII + secret detection
-Discovery                       [Out of Scope] Requires behavioral analysis (pattern matching limitation)
-Collection                      ██████████ Data theft detection
-Exfiltration                    ██████████ Input/output + markdown exfiltration
-Impact                          ██████████ Token exhaustion + harmful content
+Reconnaissance                  [Out of Scope] Pre-LLM attacker activity
+Resource Development            [Out of Scope] Attack infrastructure (external)
+Initial Access                  ██████████ T0051 / T0051.001 / T0054 / T0056
+ML Model Access                 [Out of Scope] Infrastructure authentication
+Execution                       ██████████ T0053 / T0050
+Persistence                     ██████████ T0080
+Defense Evasion                 ██████████ Normalisation + jailbreak prevention
+Credential Access               ██████████ T0056 / T0057
+Lateral Movement                ██████████ T0070 (RAG poisoning)
+Collection                      ██████████ T0024 / T0025 / T0057
+Exfiltration                    ██████████ T0024 / T0025 (markdown / API path)
+Impact                          ██████████ T0029 / T0105
+Supply Chain                    ██████████ T0010 / T0109 / T0110
 ```
 
 ---
 
 ## Compliance Statement
 
-Aigis provides technical controls aligned with MITRE ATLAS adversarial techniques for AI systems.
+Aigis provides technical controls aligned with MITRE ATLAS adversarial techniques
+for AI systems. All technique IDs in this document are anchored to the current
+official ATLAS matrix.
 
-- **All runtime-detectable ATLAS techniques are covered** (40/67). The 27 uncovered techniques are in Reconnaissance, Resource Development, and infrastructure-level tactics that occur before or outside the LLM runtime — they require organizational/infrastructure controls, not input/output scanning.
-- **100% coverage** in the most critical LLM attack paths: Initial Access, Privilege Escalation, Credential Access, and Exfiltration
-- **Continuously expanding** through weekly research-driven pattern updates
-
-Organizations can use this matrix to demonstrate comprehensive AI threat coverage at the runtime layer in security assessments and compliance documentation.
+- **15 runtime-detectable techniques covered**, verified against source patterns
+  and cross-referenced with Agent Threat Rules (ATR) — see
+  [ATR_CROSSWALK.md](./ATR_CROSSWALK.md).
+- **5 runtime gaps documented** above; contributions welcome.
+- **14 out-of-scope techniques** correctly outside input/output scanning.
+- Pattern set updated continuously; see `CHANGELOG.md` for per-cycle additions.


### PR DESCRIPTION
## Summary

Fixes the ATLAS numbering drift flagged in [ATR_CROSSWALK.md](docs/compliance/ATR_CROSSWALK.md) (merged in #154) and tracked in #166.

## What was wrong

The previous `MITRE_ATLAS_COVERAGE.md` used a non-standard numbering scheme:

| Old entry | Problem |
|---|---|
| AML.T0057 = "LLM Plugin Compromise" | Current ATLAS: T0057 = **LLM Data Leakage** |
| AML.T0058–T0065 | Not in current official ATLAS matrix |
| AML.T0066–T0072 | Custom IDs, not in current official ATLAS matrix |

## What changed

- Every technique ID is now anchored to the current official ATLAS matrix, cross-referenced against ATR_CROSSWALK.md
- **15 covered techniques** documented with verified pattern IDs
- **5 runtime gaps** added (techniques detectable in principle, no Aigis pattern yet)
- **14 out-of-scope techniques** listed (training/infrastructure)
- Migration note added explaining the prior drift

## Scope

Documentation only — no detection logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)