### PR TITLE
feat: wire SignedAuditLog into Claude Code hook for --policy enterprise (closes #129)

### DIFF
--- a/aigis/adapters/claude_code.py
+++ b/aigis/adapters/claude_code.py
@@ -111,6 +111,13 @@ def main():
     except Exception:
         pass
 
+    # Append to signed audit log (enterprise policy — key must exist).
+    # Failures here MUST NOT change the allow/deny decision.
+    try:
+        _append_signed_log(event, decision, cwd)
+    except Exception:
+        pass
+
     # Block if policy denies
     if decision == "deny":
         reason = f"Aigis blocked: {event.policy_rule_id}"
@@ -175,6 +182,66 @@ def _get_scannable_text(tool_name: str, tool_input: dict) -> str:
     elif tool_name == "WebSearch":
         return tool_input.get("query", "")
     return ""
+
+
+def _append_signed_log(event, decision: str, cwd: str) -> None:
+    """Append one tamper-evident entry to the signed audit log.
+
+    No-op when the audit key has not been initialised (non-enterprise install).
+    The caller catches all exceptions so the tool-call decision path is never
+    blocked by a signed-log failure.
+    """
+    import hashlib
+    import hmac as _hmac
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    key_path = Path(cwd) / ".aigis" / "audit_key"
+    log_path = Path(cwd) / ".aigis" / "signed_audit.jsonl"
+
+    if not key_path.exists():
+        return  # Key not initialised — signed log is opt-in
+
+    key = key_path.read_text(encoding="utf-8").strip().encode("utf-8")
+
+    # Read only the last line to get prev_hash and next sequence number.
+    prev_hash = "0" * 64
+    sequence = 0
+    if log_path.exists():
+        last_line = ""
+        with open(log_path, encoding="utf-8") as fh:
+            for line in fh:
+                if line.strip():
+                    last_line = line.strip()
+        if last_line:
+            last = json.loads(last_line)
+            canon = json.dumps(last, sort_keys=True, ensure_ascii=False)
+            prev_hash = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+            sequence = last.get("sequence", 0) + 1
+
+    entry_data = {
+        "sequence": sequence,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "event_type": event.event_type,
+        "actor": "claude_code_agent",
+        "action": event.action,
+        "target": (event.target or "")[:500],
+        "risk_score": event.risk_score or 0,
+        "outcome": decision,
+        "details": {
+            "session_id": event.session_id or "",
+            "policy_rule_id": getattr(event, "policy_rule_id", "") or "",
+            "tool_name": (event.details or {}).get("tool_name", ""),
+        },
+        "prev_hash": prev_hash,
+    }
+    canonical = json.dumps(entry_data, sort_keys=True, ensure_ascii=False)
+    sig = _hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    entry_data["signature"] = sig
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry_data, sort_keys=True, ensure_ascii=False) + "\\n")
 
 
 if __name__ == "__main__":

--- a/aigis/adapters/claude_code.py
+++ b/aigis/adapters/claude_code.py
@@ -187,9 +187,9 @@ def _get_scannable_text(tool_name: str, tool_input: dict) -> str:
 def _append_signed_log(event, decision: str, cwd: str) -> None:
     """Append one tamper-evident entry to the signed audit log.
 
+    Silently swallows all errors so a write failure never affects the
+    tool-call allow/deny decision path.
     No-op when the audit key has not been initialised (non-enterprise install).
-    The caller catches all exceptions so the tool-call decision path is never
-    blocked by a signed-log failure.
     """
     import hashlib
     import hmac as _hmac
@@ -197,51 +197,53 @@ def _append_signed_log(event, decision: str, cwd: str) -> None:
     from pathlib import Path
 
     key_path = Path(cwd) / ".aigis" / "audit_key"
-    log_path = Path(cwd) / ".aigis" / "signed_audit.jsonl"
-
     if not key_path.exists():
         return  # Key not initialised — signed log is opt-in
 
-    key = key_path.read_text(encoding="utf-8").strip().encode("utf-8")
+    try:
+        log_path = Path(cwd) / ".aigis" / "signed_audit.jsonl"
+        key = key_path.read_text(encoding="utf-8").strip().encode("utf-8")
 
-    # Read only the last line to get prev_hash and next sequence number.
-    prev_hash = "0" * 64
-    sequence = 0
-    if log_path.exists():
-        last_line = ""
-        with open(log_path, encoding="utf-8") as fh:
-            for line in fh:
-                if line.strip():
-                    last_line = line.strip()
-        if last_line:
-            last = json.loads(last_line)
-            canon = json.dumps(last, sort_keys=True, ensure_ascii=False)
-            prev_hash = hashlib.sha256(canon.encode("utf-8")).hexdigest()
-            sequence = last.get("sequence", 0) + 1
+        # Read only the last line to get prev_hash and next sequence number.
+        prev_hash = "0" * 64
+        sequence = 0
+        if log_path.exists():
+            last_line = ""
+            with open(log_path, encoding="utf-8") as fh:
+                for line in fh:
+                    if line.strip():
+                        last_line = line.strip()
+            if last_line:
+                last = json.loads(last_line)
+                canon = json.dumps(last, sort_keys=True, ensure_ascii=False)
+                prev_hash = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+                sequence = last.get("sequence", 0) + 1
 
-    entry_data = {
-        "sequence": sequence,
-        "timestamp": datetime.now(UTC).isoformat(),
-        "event_type": event.event_type,
-        "actor": "claude_code_agent",
-        "action": event.action,
-        "target": (event.target or "")[:500],
-        "risk_score": event.risk_score or 0,
-        "outcome": decision,
-        "details": {
-            "session_id": event.session_id or "",
-            "policy_rule_id": getattr(event, "policy_rule_id", "") or "",
-            "tool_name": (event.details or {}).get("tool_name", ""),
-        },
-        "prev_hash": prev_hash,
-    }
-    canonical = json.dumps(entry_data, sort_keys=True, ensure_ascii=False)
-    sig = _hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
-    entry_data["signature"] = sig
+        entry_data = {
+            "sequence": sequence,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event_type": event.event_type,
+            "actor": "claude_code_agent",
+            "action": event.action,
+            "target": (event.target or "")[:500],
+            "risk_score": event.risk_score or 0,
+            "outcome": decision,
+            "details": {
+                "session_id": event.session_id or "",
+                "policy_rule_id": getattr(event, "policy_rule_id", "") or "",
+                "tool_name": (event.details or {}).get("tool_name", ""),
+            },
+            "prev_hash": prev_hash,
+        }
+        canonical = json.dumps(entry_data, sort_keys=True, ensure_ascii=False)
+        sig = _hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+        entry_data["signature"] = sig
 
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(log_path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(entry_data, sort_keys=True, ensure_ascii=False) + "\\n")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry_data, sort_keys=True, ensure_ascii=False) + "\\n")
+    except Exception:
+        pass  # fail-safe: signed log errors must never block tool calls
 
 
 if __name__ == "__main__":

--- a/aigis/cli.py
+++ b/aigis/cli.py
@@ -1051,7 +1051,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
             _pol = _lp(str(policy_path))
             _policy_is_enterprise = "enterprise" in _pol.name.lower()
-        except Exception:
+        except Exception:  # policy file may be absent or unreadable; fall back to non-enterprise
             pass
 
     if key_file.exists():

--- a/aigis/cli.py
+++ b/aigis/cli.py
@@ -556,6 +556,14 @@ def cmd_init(args: argparse.Namespace) -> int:
         install_hooks(".")
         print("  Configured Claude Code hooks")
 
+    # Enterprise policy: initialise signed audit log key
+    if args.policy == "enterprise":
+        from aigis.audit.signed_log import _resolve_key
+
+        _resolve_key(None)  # generates .aigis/audit_key if absent
+        print("  Initialised signed audit log key (.aigis/audit_key)")
+        print("  Signed audit log will be written to .aigis/signed_audit.jsonl")
+
     # Warn if hooks are disabled
     _warn_if_hooks_disabled(project_dir=".")
 
@@ -1032,6 +1040,35 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             warn("Global log directory exists but has no log files")
     else:
         warn("Global log directory not found (~/.aigis/global/)")
+
+    # 9. Signed audit log (required under enterprise policy; opt-in otherwise)
+    key_file = Path(".aigis") / "audit_key"
+    signed_log_file = Path(".aigis") / "signed_audit.jsonl"
+    _policy_is_enterprise = False
+    if policy_path.exists():
+        try:
+            from aigis.policy import load_policy as _lp
+
+            _pol = _lp(str(policy_path))
+            _policy_is_enterprise = "enterprise" in _pol.name.lower()
+        except Exception:
+            pass
+
+    if key_file.exists():
+        if signed_log_file.exists() and signed_log_file.stat().st_size > 0:
+            ok("Signed audit log: ACTIVE (.aigis/signed_audit.jsonl)")
+        else:
+            warn(
+                "Signed audit log: key present but no entries yet "
+                "(run a tool call to populate)"
+            )
+    elif _policy_is_enterprise:
+        fail(
+            "Signed audit log: INACTIVE — enterprise policy requires signed log. "
+            "Run 'aigis init --policy enterprise' to initialise."
+        )
+    else:
+        ok("Signed audit log: not enabled (opt-in via 'aigis init --policy enterprise')")
 
     # Summary
     print()

--- a/aigis/cli.py
+++ b/aigis/cli.py
@@ -1058,10 +1058,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         if signed_log_file.exists() and signed_log_file.stat().st_size > 0:
             ok("Signed audit log: ACTIVE (.aigis/signed_audit.jsonl)")
         else:
-            warn(
-                "Signed audit log: key present but no entries yet "
-                "(run a tool call to populate)"
-            )
+            warn("Signed audit log: key present but no entries yet (run a tool call to populate)")
     elif _policy_is_enterprise:
         fail(
             "Signed audit log: INACTIVE — enterprise policy requires signed log. "

--- a/tests/test_signed_audit_hook.py
+++ b/tests/test_signed_audit_hook.py
@@ -66,7 +66,7 @@ def test_init_enterprise_creates_audit_key(tmp_path):
 
 
 def test_signed_log_failure_does_not_block(tmp_path):
-    """_append_signed_log raises, but the caller swallows it — decision unchanged."""
+    """_append_signed_log swallows write errors internally — decision unchanged."""
     ns = _load_hook_ns()
     _append = ns["_append_signed_log"]
 

--- a/tests/test_signed_audit_hook.py
+++ b/tests/test_signed_audit_hook.py
@@ -7,14 +7,12 @@ Acceptance criteria:
   AC4. hook writes a verifiable entry to signed_audit.jsonl
 """
 
+import hashlib
+import hmac as _hmac
 import json
-import os
-import sys
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -33,19 +31,24 @@ def _make_event(action="shell:exec", target="ls", decision="allow"):
     return ev, decision
 
 
+def _load_hook_ns():
+    from aigis.adapters.claude_code import HOOK_SCRIPT
+
+    ns: dict = {}
+    exec(HOOK_SCRIPT, ns)  # noqa: S102 — executing generated hook script in test
+    return ns
+
+
 # ---------------------------------------------------------------------------
 # AC1 — init --policy enterprise initialises audit key
 # ---------------------------------------------------------------------------
 
 
-def test_init_enterprise_creates_audit_key(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    from aigis.audit.signed_log import _KEY_FILE
-
-    # Temporarily point _KEY_FILE to tmp_path
+def test_init_enterprise_creates_audit_key(tmp_path):
     import aigis.audit.signed_log as sal
 
-    orig = sal._KEY_FILE
+    orig_file = sal._KEY_FILE
+    orig_dir = sal._KEY_DIR
     sal._KEY_FILE = tmp_path / ".aigis" / "audit_key"
     sal._KEY_DIR = tmp_path / ".aigis"
 
@@ -53,8 +56,8 @@ def test_init_enterprise_creates_audit_key(tmp_path, monkeypatch):
         sal._resolve_key(None)
         assert sal._KEY_FILE.exists(), "audit_key should be created by _resolve_key()"
     finally:
-        sal._KEY_FILE = orig
-        sal._KEY_DIR = orig.parent
+        sal._KEY_FILE = orig_file
+        sal._KEY_DIR = orig_dir
 
 
 # ---------------------------------------------------------------------------
@@ -64,37 +67,31 @@ def test_init_enterprise_creates_audit_key(tmp_path, monkeypatch):
 
 def test_signed_log_failure_does_not_block(tmp_path):
     """_append_signed_log raises, but the caller swallows it — decision unchanged."""
-    # Import the _append_signed_log function from the hook script via exec
-    from aigis.adapters.claude_code import HOOK_SCRIPT
-
-    ns: dict = {}
-    exec(HOOK_SCRIPT, ns)  # noqa: S102 — executing generated hook script in test
+    ns = _load_hook_ns()
     _append = ns["_append_signed_log"]
 
     ev, decision = _make_event()
 
-    # Point to a read-only directory to trigger a write failure
     ro_dir = tmp_path / "readonly"
     ro_dir.mkdir()
     key_file = ro_dir / ".aigis" / "audit_key"
     key_file.parent.mkdir(parents=True)
     key_file.write_text("deadbeef" * 8)
 
-    # Make the log path's parent read-only (Unix only; skip on Windows)
+    # Make the .aigis dir read-only to trigger a write failure (Unix only)
     try:
         (ro_dir / ".aigis").chmod(0o555)
     except (OSError, NotImplementedError):
         pytest.skip("Cannot set read-only permissions on this platform")
 
     try:
-        # Must not raise — all exceptions are caught by the caller
         _append(ev, decision, str(ro_dir))
     except Exception as exc:
         pytest.fail(f"_append_signed_log raised unexpectedly: {exc}")
     finally:
         try:
             (ro_dir / ".aigis").chmod(0o755)
-        except OSError:
+        except OSError:  # best-effort cleanup
             pass
 
 
@@ -105,16 +102,11 @@ def test_signed_log_failure_does_not_block(tmp_path):
 
 def test_hook_skips_signed_log_without_key(tmp_path):
     """When audit_key does not exist, hook silently skips signed log."""
-    from aigis.adapters.claude_code import HOOK_SCRIPT
-
-    ns: dict = {}
-    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    ns = _load_hook_ns()
     _append = ns["_append_signed_log"]
 
     ev, decision = _make_event()
-    cwd = str(tmp_path)  # no .aigis/audit_key here
-
-    _append(ev, decision, cwd)  # must not raise and must not create anything
+    _append(ev, decision, str(tmp_path))  # must not raise and must not create anything
     assert not (tmp_path / ".aigis" / "signed_audit.jsonl").exists()
 
 
@@ -125,16 +117,9 @@ def test_hook_skips_signed_log_without_key(tmp_path):
 
 def test_hook_writes_verifiable_entry(tmp_path):
     """A single hook invocation produces a valid HMAC-signed JSONL entry."""
-    import hashlib
-    import hmac as _hmac
-
-    from aigis.adapters.claude_code import HOOK_SCRIPT
-
-    ns: dict = {}
-    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    ns = _load_hook_ns()
     _append = ns["_append_signed_log"]
 
-    # Set up key
     aig_dir = tmp_path / ".aigis"
     aig_dir.mkdir()
     key = "test-key-for-unit-test"
@@ -145,7 +130,7 @@ def test_hook_writes_verifiable_entry(tmp_path):
 
     log_file = aig_dir / "signed_audit.jsonl"
     assert log_file.exists(), "signed_audit.jsonl should be created"
-    lines = [l for l in log_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    lines = [ln for ln in log_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
     assert len(lines) == 1, "exactly one entry expected"
 
     entry = json.loads(lines[0])
@@ -165,12 +150,7 @@ def test_hook_writes_verifiable_entry(tmp_path):
 
 def test_hook_chains_entries(tmp_path):
     """Second entry's prev_hash equals SHA-256 of the first entry."""
-    import hashlib
-
-    from aigis.adapters.claude_code import HOOK_SCRIPT
-
-    ns: dict = {}
-    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    ns = _load_hook_ns()
     _append = ns["_append_signed_log"]
 
     aig_dir = tmp_path / ".aigis"
@@ -184,11 +164,11 @@ def test_hook_chains_entries(tmp_path):
     _append(ev2, d2, str(tmp_path))
 
     lines = [
-        l
-        for l in (aig_dir / "signed_audit.jsonl")
+        ln
+        for ln in (aig_dir / "signed_audit.jsonl")
         .read_text(encoding="utf-8")
         .splitlines()
-        if l.strip()
+        if ln.strip()
     ]
     assert len(lines) == 2
 

--- a/tests/test_signed_audit_hook.py
+++ b/tests/test_signed_audit_hook.py
@@ -1,0 +1,200 @@
+"""Tests for signed audit log integration in the Claude Code hook (issue #129).
+
+Acceptance criteria:
+  AC1. init --policy enterprise initialises .aigis/audit_key
+  AC2. hook append failure never changes allow/deny behaviour
+  AC3. developer policy behaviour unchanged (no key auto-created)
+  AC4. hook writes a verifiable entry to signed_audit.jsonl
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(action="shell:exec", target="ls", decision="allow"):
+    ev = MagicMock()
+    ev.event_type = "tool_call"
+    ev.action = action
+    ev.target = target
+    ev.risk_score = 0
+    ev.session_id = "sess-test"
+    ev.policy_rule_id = ""
+    ev.details = {"tool_name": "Bash"}
+    return ev, decision
+
+
+# ---------------------------------------------------------------------------
+# AC1 — init --policy enterprise initialises audit key
+# ---------------------------------------------------------------------------
+
+
+def test_init_enterprise_creates_audit_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from aigis.audit.signed_log import _KEY_FILE
+
+    # Temporarily point _KEY_FILE to tmp_path
+    import aigis.audit.signed_log as sal
+
+    orig = sal._KEY_FILE
+    sal._KEY_FILE = tmp_path / ".aigis" / "audit_key"
+    sal._KEY_DIR = tmp_path / ".aigis"
+
+    try:
+        sal._resolve_key(None)
+        assert sal._KEY_FILE.exists(), "audit_key should be created by _resolve_key()"
+    finally:
+        sal._KEY_FILE = orig
+        sal._KEY_DIR = orig.parent
+
+
+# ---------------------------------------------------------------------------
+# AC2 — signed-log write failure does NOT change hook allow/deny
+# ---------------------------------------------------------------------------
+
+
+def test_signed_log_failure_does_not_block(tmp_path):
+    """_append_signed_log raises, but the caller swallows it — decision unchanged."""
+    # Import the _append_signed_log function from the hook script via exec
+    from aigis.adapters.claude_code import HOOK_SCRIPT
+
+    ns: dict = {}
+    exec(HOOK_SCRIPT, ns)  # noqa: S102 — executing generated hook script in test
+    _append = ns["_append_signed_log"]
+
+    ev, decision = _make_event()
+
+    # Point to a read-only directory to trigger a write failure
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    key_file = ro_dir / ".aigis" / "audit_key"
+    key_file.parent.mkdir(parents=True)
+    key_file.write_text("deadbeef" * 8)
+
+    # Make the log path's parent read-only (Unix only; skip on Windows)
+    try:
+        (ro_dir / ".aigis").chmod(0o555)
+    except (OSError, NotImplementedError):
+        pytest.skip("Cannot set read-only permissions on this platform")
+
+    try:
+        # Must not raise — all exceptions are caught by the caller
+        _append(ev, decision, str(ro_dir))
+    except Exception as exc:
+        pytest.fail(f"_append_signed_log raised unexpectedly: {exc}")
+    finally:
+        try:
+            (ro_dir / ".aigis").chmod(0o755)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# AC3 — developer policy: no key auto-created by hook
+# ---------------------------------------------------------------------------
+
+
+def test_hook_skips_signed_log_without_key(tmp_path):
+    """When audit_key does not exist, hook silently skips signed log."""
+    from aigis.adapters.claude_code import HOOK_SCRIPT
+
+    ns: dict = {}
+    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    _append = ns["_append_signed_log"]
+
+    ev, decision = _make_event()
+    cwd = str(tmp_path)  # no .aigis/audit_key here
+
+    _append(ev, decision, cwd)  # must not raise and must not create anything
+    assert not (tmp_path / ".aigis" / "signed_audit.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC4 — hook writes a verifiable entry
+# ---------------------------------------------------------------------------
+
+
+def test_hook_writes_verifiable_entry(tmp_path):
+    """A single hook invocation produces a valid HMAC-signed JSONL entry."""
+    import hashlib
+    import hmac as _hmac
+
+    from aigis.adapters.claude_code import HOOK_SCRIPT
+
+    ns: dict = {}
+    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    _append = ns["_append_signed_log"]
+
+    # Set up key
+    aig_dir = tmp_path / ".aigis"
+    aig_dir.mkdir()
+    key = "test-key-for-unit-test"
+    (aig_dir / "audit_key").write_text(key)
+
+    ev, decision = _make_event(action="shell:exec", target="ls -la", decision="allow")
+    _append(ev, decision, str(tmp_path))
+
+    log_file = aig_dir / "signed_audit.jsonl"
+    assert log_file.exists(), "signed_audit.jsonl should be created"
+    lines = [l for l in log_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 1, "exactly one entry expected"
+
+    entry = json.loads(lines[0])
+    assert entry["sequence"] == 0
+    assert entry["action"] == "shell:exec"
+    assert entry["outcome"] == "allow"
+    assert entry["prev_hash"] == "0" * 64  # genesis hash
+
+    # Verify HMAC
+    sig = entry.pop("signature")
+    canonical = json.dumps(entry, sort_keys=True, ensure_ascii=False)
+    expected_sig = _hmac.new(
+        key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    assert sig == expected_sig, "HMAC signature must be valid"
+
+
+def test_hook_chains_entries(tmp_path):
+    """Second entry's prev_hash equals SHA-256 of the first entry."""
+    import hashlib
+
+    from aigis.adapters.claude_code import HOOK_SCRIPT
+
+    ns: dict = {}
+    exec(HOOK_SCRIPT, ns)  # noqa: S102
+    _append = ns["_append_signed_log"]
+
+    aig_dir = tmp_path / ".aigis"
+    aig_dir.mkdir()
+    (aig_dir / "audit_key").write_text("chain-test-key")
+
+    ev1, d1 = _make_event(action="file:read", target="a.py", decision="allow")
+    ev2, d2 = _make_event(action="shell:exec", target="ls", decision="allow")
+
+    _append(ev1, d1, str(tmp_path))
+    _append(ev2, d2, str(tmp_path))
+
+    lines = [
+        l
+        for l in (aig_dir / "signed_audit.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if l.strip()
+    ]
+    assert len(lines) == 2
+
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+
+    canon1 = json.dumps(first, sort_keys=True, ensure_ascii=False)
+    expected_prev = hashlib.sha256(canon1.encode("utf-8")).hexdigest()
+    assert second["prev_hash"] == expected_prev, "hash chain must link entry 0 → entry 1"

--- a/tests/test_signed_audit_hook.py
+++ b/tests/test_signed_audit_hook.py
@@ -165,9 +165,7 @@ def test_hook_chains_entries(tmp_path):
 
     lines = [
         ln
-        for ln in (aig_dir / "signed_audit.jsonl")
-        .read_text(encoding="utf-8")
-        .splitlines()
+        for ln in (aig_dir / "signed_audit.jsonl").read_text(encoding="utf-8").splitlines()
         if ln.strip()
     ]
     assert len(lines) == 2


### PR DESCRIPTION
## Summary

Wires the tamper-evident `SignedAuditLog` (HMAC-SHA256 + hash chain) into the Claude Code PreToolUse hook path, active by default when `--policy enterprise` is used.

## Changes

### `aigis/adapters/claude_code.py`
- Added `_append_signed_log(event, decision, cwd)` inside `HOOK_SCRIPT`
- Called after `ActivityStream.record()`, wrapped in `try/except` — signed-log failures **never** block or change the allow/deny decision
- Skips silently when `.aigis/audit_key` is absent (developer/reviewer policy unchanged)

### `aigis/cli.py`
- `cmd_init`: `--policy enterprise` now calls `_resolve_key(None)` to generate `.aigis/audit_key` on first init
- `cmd_doctor`: new check #9 — reports `ACTIVE` / `key present but no entries yet` / `INACTIVE (enterprise requires key)`, only fails under enterprise policy

### `tests/test_signed_audit_hook.py`
5 new tests covering all acceptance criteria:
- `test_init_enterprise_creates_audit_key` — AC1
- `test_signed_log_failure_does_not_block` — AC2
- `test_hook_skips_signed_log_without_key` — AC3
- `test_hook_writes_verifiable_entry` — AC4 (HMAC signature verified)
- `test_hook_chains_entries` — hash chain integrity

## Acceptance criteria

- [x] `aigis init --agent claude-code --policy enterprise` → `audit_key` created; next tool call → `.aigis/signed_audit.jsonl` populated; `aigis audit verify` exits 0
- [x] Signed-log write failure does not change allow/deny (test + try/except)
- [x] `developer` policy: no key auto-created, no signed log written
- [ ] Docs update (`docs/trust-pack.md`, `it-security-checklist`) — follow-up

## Test results

1765 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)