### PR TITLE
fix(ci): unify codeql-action init/analyze/upload-sarif versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- `github/codeql-action/init` was pinned to v4.36.3 while `analyze` and `upload-sarif` had already moved to v4.37.3 via separate Dependabot PRs. codeql-action's `init` step writes its version into a local config file that `analyze`/`upload-sarif` validate against, so any mismatch fails every language matrix job with `Loaded a configuration file for version X, but running version Y` — confirmed via `gh run view --log-failed` on recent failing runs. This is the root cause of the `Analyze (*)` job failures seen across essentially every PR this cycle.
- Unified `init`/`analyze` in `.github/workflows/codeql.yml` and `upload-sarif` in `.github/workflows/scorecard.yml` to the same commit (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` = v4.37.3).
- Added a `groups` entry for `github/codeql-action/*` in `.github/dependabot.yml` so `init`/`analyze`/`upload-sarif` are bumped together in one PR going forward, preventing this version-split from recurring.

## Test plan
- [ ] `Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (actions)` all pass (previously failing with configuration error)
- [ ] Required checks (Lint, Test 3.11/3.12, DCO) pass