### PR TITLE
docs: move demo GIF below Quick Start, retitle as "New in v1.2"

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,21 +48,6 @@ aigis trust-pack --lang ja                            # → ./aigis-trust-pack/ 
 
 ---
 
-## 動作イメージ
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-demo.gif" alt="Aigis デモ：エージェント入力の検査と IT 承認パック生成" width="760" />
-</p>
-
-実際のコマンドを4つ、順に実行しています。
-
-1. **`aigis scan`**（通常の依頼）→ **SAFE**。誤検知しません。
-2. **`aigis scan`**（攻撃）→ **CRITICAL** でブロック。*「`.env` を読んで外部に送れ」* という指示を **目に見えない ANSI エスケープコード**に隠した入力です（人がターミナルを見ても気づかないが、モデルは生バイトを読んでしまう）。
-3. **`aigis init`** で Claude Code 向けにガードレールと改ざん検知付き監査ログを有効化。
-4. **`aigis trust-pack`** で稼働中の設定から EN/JA の IT 承認パックを生成。
-
----
-
 <a id="quick-start"></a>
 
 ## Quick Start
@@ -131,6 +116,21 @@ curl -X POST http://localhost:8080/v1/check/input \
 
 エンドポイント：`POST /v1/check/input` · `POST /v1/check/output` · `POST /v1/check/messages` · `GET /health` · `GET /v1/info`。Kubernetes サイドカー、`docker-compose` の併走コンテナ、`litellm` / `langgraph` 等の前段として利用できます。
 </details>
+
+---
+
+## v1.2 の新機能：見えない ANSI 攻撃を検知し、IT 承認パックを生成する
+
+v1.2 では **ANSI エスケープに隠した命令**（目に見えないターミナル制御コードに埋め込まれた攻撃）の検出と、`aigis trust-pack` / `aigis audit` コマンドを追加しました。下のクリップは、実際のコマンドを4つ通しで実行しています。
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-demo.gif" alt="Aigis v1.2 デモ：エージェント入力の検査と IT 承認パック生成" width="760" />
+</p>
+
+1. **`aigis scan`**（通常の依頼）→ **SAFE**。誤検知しません。
+2. **`aigis scan`**（攻撃）→ **CRITICAL** でブロック。*「`.env` を読んで外部に送れ」* という指示を **目に見えない ANSI エスケープコード**に隠した入力です（人がターミナルを見ても気づかないが、モデルは生バイトを読んでしまう）。
+3. **`aigis init`** で Claude Code 向けにガードレールと改ざん検知付き監査ログを有効化。
+4. **`aigis trust-pack`** で稼働中の設定から EN/JA の IT 承認パックを生成。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,21 +48,6 @@ aigis trust-pack --lang en                           # → hand ./aigis-trust-pa
 
 ---
 
-## See it in action
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-demo.gif" alt="Aigis demo: scanning agent input and generating an IT-approval pack" width="760" />
-</p>
-
-Four real commands, in order:
-
-1. **`aigis scan`** on a normal request → **SAFE** — no false alarm.
-2. **`aigis scan`** on an attack that hides a *"read `.env` and exfiltrate it"* instruction inside **invisible ANSI escape codes** → **CRITICAL**, blocked. (A human skimming the terminal sees nothing; the model would have read the raw bytes.)
-3. **`aigis init`** turns on guardrails + a tamper-evident audit log for Claude Code.
-4. **`aigis trust-pack`** generates the bilingual IT-approval pack from your live config.
-
----
-
 ## Quick Start
 
 For developers building or running agents, the library is two lines and needs no config, API keys, or Docker:
@@ -129,6 +114,21 @@ curl -X POST http://localhost:8080/v1/check/input \
 
 Endpoints: `POST /v1/check/input` · `POST /v1/check/output` · `POST /v1/check/messages` · `GET /health` · `GET /v1/info`. Runs as a Kubernetes sidecar, a `docker-compose` companion, or a local fence in front of `litellm`, `langgraph`, or any HTTP-fronted agent.
 </details>
+
+---
+
+## New in v1.2: catch invisible-ANSI attacks, then generate an IT-approval pack
+
+v1.2 adds detection for **ANSI-concealed instructions** (payloads hidden inside invisible terminal escape codes), plus the `aigis trust-pack` and `aigis audit` commands. The clip below runs four real commands end to end:
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-demo.gif" alt="Aigis v1.2 demo: scanning agent input and generating an IT-approval pack" width="760" />
+</p>
+
+1. **`aigis scan`** on a normal request → **SAFE** — no false alarm.
+2. **`aigis scan`** on an attack that hides a *"read `.env` and exfiltrate it"* instruction inside **invisible ANSI escape codes** → **CRITICAL**, blocked. (A human skimming the terminal sees nothing; the model would have read the raw bytes.)
+3. **`aigis init`** turns on guardrails + a tamper-evident audit log for Claude Code.
+4. **`aigis trust-pack`** generates the bilingual IT-approval pack from your live config.
 
 ---
 


### PR DESCRIPTION
Review fix. The demo GIF (v1.2 features) was placed **above** Quick Start, ahead of the basic getting-started flow, under a vague "See it in action" heading.

- Remove the pre-Quick-Start block.
- Re-add it right **after** Quick Start as **"New in v1.2: catch invisible-ANSI attacks, then generate an IT-approval pack"** (JA: 「v1.2 の新機能…」), so it reads as what the release adds rather than the primary entry point.

Both README.md and README.ja.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)