### PR TITLE
release: v2.0.1, and make preflight catch a burned version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,16 @@ what got documented across releases.
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-08-17
+## [2.0.1] - 2026-08-24
+
+> **On the version number.** This is the first 2.x release; there is no usable
+> 2.0.0. That version was uploaded to PyPI on 2026-04-11, during early
+> development and before the project settled on 0.0.x and then 1.x, and PyPI
+> refuses re-uploads even for a version whose files have been deleted — so the
+> number is permanently burned. A `v2.0.0` tag was created and then deleted on
+> 2026-08-24, after `release.yml` failed at the publish step with
+> "400 File already exists". `release_preflight.sh` now queries PyPI before a
+> tag is pushed (exit 6), so a burned number is caught before it costs a tag.
 
 Aigis stops competing on detection-pattern count and becomes the tool that gets an
 AI agent through a company's security review. [ROADMAP.md](ROADMAP.md) records the

--- a/auto-improvement/scripts/release_preflight.sh
+++ b/auto-improvement/scripts/release_preflight.sh
@@ -11,6 +11,8 @@
 #   4  — local branch is not on the master tip (so the tag would point
 #         somewhere humans haven't reviewed); abort
 #   5  — usage error
+#   6  — version already published on PyPI; abort (the number is burned —
+#         PyPI refuses re-uploads even after a file is deleted)
 #
 # Usage:
 #   ./release_preflight.sh vX.Y.Z              # checks current HEAD
@@ -41,7 +43,14 @@ fi
 echo "[preflight] checking $TAG against $SHA"
 
 # 1. Refresh remote view of tags + master.
-git fetch --quiet origin --tags
+#
+# --force matters here. A local tag that diverges from the remote makes
+# `git fetch --tags` exit non-zero ("would clobber existing tag"), and under
+# `set -e` that aborts this script before a single check runs — turning the
+# gatekeeper into a silent no-op. v1.1.9 was exactly that case: it pointed at
+# cycle 3 locally and cycle 4 on the remote, a leftover of the v1.1.x tag
+# incident. The remote is authoritative for what was published, so take it.
+git fetch --quiet --force origin --tags
 git fetch --quiet origin master
 
 RESOLVED_SHA=$(git rev-parse --verify "$SHA^{commit}" 2>/dev/null || true)
@@ -110,6 +119,53 @@ Recovery:
      (e.g. cutting a patch release for a previous minor).
 MSG
   exit 4
+fi
+
+# 5. PyPI collision check — the git tag can be clean while the version number
+#    is already burned on PyPI. That is exactly what happened to v2.0.0: it was
+#    uploaded on 2026-04-11 during early development, the project then moved to
+#    0.0.x and 1.x, and the number stayed unusable. Checks 2-4 all passed, the
+#    tag was pushed, and release.yml failed at the publish step with
+#    "400 File already exists" — after which the tag had to be deleted again.
+#
+#    PyPI refuses a re-upload even for a version whose files were deleted, so
+#    this has to be caught before the tag goes out.
+REPO_ROOT=$(git rev-parse --show-toplevel)
+# A missing pyproject.toml is normal: the preflight tests run this script
+# inside a bare fixture repo. Guard the read, because under `set -e` awk's
+# file-not-found (exit 2) would abort the whole script — and exit 2 is also
+# the tag-collision code, so the failure would masquerade as a real verdict.
+PKG=""
+if [[ -f "$REPO_ROOT/pyproject.toml" ]]; then
+  PKG=$(awk -F'"' '/^name = /{print $2; exit}' "$REPO_ROOT/pyproject.toml" || true)
+fi
+VERSION="${TAG#v}"
+
+if [[ -n "$PKG" ]] && command -v curl >/dev/null 2>&1; then
+  PYPI_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "https://pypi.org/pypi/$PKG/$VERSION/json" 2>/dev/null || echo "000")
+
+  if [[ "$PYPI_STATUS" == "200" ]]; then
+    cat >&2 <<MSG
+[preflight] FAIL (exit 6) — $PKG $VERSION is already published on PyPI.
+
+The tag checks passed, but the version number is burned: PyPI rejects a
+re-upload of an existing version, and deleting its files does not free the
+number. Pushing the tag would leave a tag with no release behind it.
+
+Recovery:
+  1. Do not push the tag.
+  2. Check what is actually on PyPI:
+       https://pypi.org/project/$PKG/$VERSION/
+  3. If that release is an accident from an earlier era, pick the next free
+     number, and yank the stale one on PyPI so it stops resolving as an
+     install candidate.
+MSG
+    exit 6
+  elif [[ "$PYPI_STATUS" != "404" ]]; then
+    # Offline runs and PyPI hiccups must not block a release; say so loudly
+    # rather than pretending the check ran.
+    echo "[preflight] WARN — could not confirm PyPI state for $PKG $VERSION (HTTP $PYPI_STATUS); continuing unverified" >&2
+  fi
 fi
 
 echo "[preflight] OK — $TAG can be pushed against $RESOLVED_SHA"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyaigis"
-version = "2.0.0"
+version = "2.0.1"
 description = "Open-source trust layer for adopting Claude Code and autonomous AI agents at work: deterministic guardrails on every tool call, tamper-evident audit logs, and a generated IT-approval pack (aigis trust-pack). Zero-dependency Python firewall — prompt injection, MCP tool poisoning, memory defense; 44 compliance templates across US/CN/JP/EU. Library, Docker sidecar, or CLI."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -926,7 +926,7 @@ wheels = [
 
 [[package]]
 name = "pyaigis"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why 2.0.1 and not 2.0.0

The v2.0.0 release failed. The tag was clean, reachable from master, and preflight approved it — but PyPI already had `pyaigis 2.0.0`, **uploaded on 2026-04-11**, the same day as `0.0.1`, during early development and before the project settled on 0.0.x and then 1.x.

PyPI refuses re-uploads even for a version whose files were deleted, so `release.yml` failed at the publish step with `400 File already exists`, and the tag had to be deleted again. The number is permanently burned.

```
PyPI pyaigis versions (excerpt)
  0.0.1    2026-04-11
  ...
  1.2.0    2026-08-09   ← latest
  2.0.0    2026-04-11   ← out of sequence, burned
```

**This is not the "bump and retry" pattern CLAUDE.md forbids.** That rule is about tagging an *orphan* commit, failing, then re-tagging the same orphan under a new number — the v1.1.1→v1.1.3 cascade. Here the tag pointed at master and the blocker was on PyPI's side, where bumping is the only available move.

CHANGELOG records why 2.0.0 is missing, so the gap is documented rather than mysterious.

## The part that matters more: preflight was not checking PyPI

`release_preflight.sh` verified tag collision, orphan commits, and master-tip — but never asked whether the version number was still available. It approved a release that could not exist. It now queries PyPI and **exits 6** on a burned version.

Verified in both directions rather than assumed:

```
v2.0.0 → exit 6   "pyaigis 2.0.0 is already published on PyPI"
v2.0.1 → exit 0   "can be pushed against 626ccc7"
```

## Two bugs found while building that, both of which passed while checking nothing

**`git fetch --tags` was aborting the whole script.** A local tag that diverges from the remote makes fetch exit non-zero (`would clobber existing tag`), and under `set -e` that killed the script before any check ran. `v1.1.9` was exactly that case — pointing at *cycle 3* locally and *cycle 4* on the remote, a leftover of the v1.1.x tag incident. **Every check after the fetch was dead code.** Now `--force`, and local tags have been resynced to the remote.

This also means my earlier report of "preflight exit 0" for v2.0.0 was wrong: I read `$?` through a pipe, so it was `tail`'s exit code. The script had actually died at the fetch. Master reachability was separately confirmed by hand, so the tag push itself was sound — but the gate had not run.

**The first PyPI check silently checked nothing.** It read the package name via a sed backreference that an escaping layer mangled into an empty replacement (`s/^name = "\(.*\)"//p`). `$PKG` became a control character, the URL broke, curl returned nothing, and the script printed *"could not confirm PyPI state … continuing unverified"* — reassuring text over a no-op. Replaced with `awk`, which needs no backreference.

**Plus a guard on the pyproject read.** It is absent in the preflight test's fixture repo, and awk's file-not-found is exit 2 — the same code as tag collision, so the failure would have read as a legitimate verdict.

## Verification

- **Tests: 1781 passed · 0 failed** — measured after clearing a venv that had broken mid-rebuild on a Windows file lock, not carried over from an earlier run
- The 5 existing `test_release_preflight.py` tests still pass (one of them caught the awk guard bug)
- `ruff check` and `ruff format --check` clean
- `pyproject.toml` and `uv.lock` both report 2.0.1

## After merging

```bash
git checkout master && git pull
./auto-improvement/scripts/release_preflight.sh v2.0.1   # now also checks PyPI
git tag -a v2.0.1 -m "..." && git push origin v2.0.1
```

Separately, **PyPI's stale 2.0.0 should be yanked** — not deleted, which would not free the number anyway. Left as-is, `pip install pyaigis==2.0.0` installs an April build with none of this in it. That needs PyPI credentials, so it is yours to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
