### PR TITLE
ci(scorecard): use GITHUB_TOKEN, drop the expired PAT reference

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,11 +32,18 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-          # PAT with `public_repo` + `read:org` scope to read branch protection
-          # rules. Falls back to GITHUB_TOKEN if unset (Branch-Protection check
-          # will return "?"). Create at: Settings → Secrets → Actions →
-          # SCORECARD_TOKEN. See https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
-          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN is sufficient and is what upstream recommends. A
+          # fine-grained PAT is only needed to read *classic* Branch Protection,
+          # and this repository moved to Repository Rules on 2026-08-24 — which
+          # scorecard-action reads with the default token.
+          #
+          # The PAT is deliberately not referenced any more. It had expired, and
+          # because `secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN` prefers the
+          # PAT whenever the secret exists, every run since failed with
+          # "401 Bad credentials" — a scheduled job going red weekly while the
+          # badge quietly served a stale score. An expiring credential in the
+          # fallback position fails closed and silently; the default token cannot.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## The failure

Every Scorecard run since at least 2026-08-22 failed with `401 Bad credentials` — scheduled, on push to master, and on `branch_protection_rule` alike.

```
scorecard had an error: repo unreachable:
GET https://api.github.com/repos/killertcell428/aigis: 401 Bad credentials
```

## The cause is the fallback expression itself

```yaml
repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
```

`||` prefers the PAT whenever the secret **exists**, regardless of whether it still works. `SCORECARD_TOKEN` had expired, so the fallback never engaged — the run died before it could read the repository.

**A credential that expires in the preferred position of a fallback chain fails closed and silently.** That is why this went unnoticed: a weekly red X on a scheduled job nobody watches, while the README badge kept serving a stale score.

## Why the PAT is no longer needed at all

Upstream is explicit that `GITHUB_TOKEN` is the recommended token, and that a fine-grained PAT is only required to read **classic** Branch Protection:

> Scorecard Action requires additional permissions if you use GitHub's classic Branch Protection settings and want to see it reflected in your results.
> GitHub's new Repository Rules are accessible to Scorecard Action with the workflow's default `GITHUB_TOKEN`.

This repository moved from classic Branch Protection to Repository Rules on 2026-08-24, so the PAT has no remaining job.

## The migration behind that

Done before this PR, in this order, so master was never unprotected:

1. Created ruleset `master protection` (active) — verified 5 rules applying to master
2. Confirmed via `GET /repos/.../rules/branches/master`
3. Deleted classic BP — re-confirmed the same 5 rules still apply

Every classic setting was carried over rather than approximated:

| classic BP | value | ruleset |
|---|---|---|
| `allow_deletions` | false | `deletion` |
| `allow_force_pushes` | false | `non_fast_forward` |
| `required_linear_history` | true | `required_linear_history` |
| `required_status_checks.strict` | true | `strict_required_status_checks_policy: true` |
| required checks | Lint & Type Check, Test 3.11, Test 3.12, DCO Check | same four |
| `required_conversation_resolution` | true | `required_review_thread_resolution: true` |
| approvals / dismiss stale / code owners | 0 / true / true | same |
| **`enforce_admins`** | **true** | **`bypass_actors: []`** |

The last row is the one worth double-checking: `enforce_admins: true` becomes an empty bypass list, so the repository owner cannot bypass the rules either — same as before.

## Verification

The 401 cannot be verified as fixed from a PR branch, because `scorecard.yml` only triggers on `push: [master]`, `schedule`, `branch_protection_rule`, and `workflow_dispatch`. It will run on merge; if it still fails, the remaining cause would be something other than the token, and this PR narrows it to that.

`SCORECARD_TOKEN` can be deleted from repository settings — nothing references it now. Leaving it in place is harmless but misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
