### PR TITLE
fix(ci): demo-gif dropped the rendered GIF when the tape was not the default

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -52,17 +52,30 @@ jobs:
           ffmpeg -version | head -1; ttyd --version; vhs --version
 
       - name: Render tape → GIF
+        id: render
         env:
           TAPE: ${{ inputs.tape || 'docs/demo/aigis-demo.tape' }}
         run: |
           set -euo pipefail
           test -f "$TAPE" || { echo "::error::tape not found: $TAPE"; exit 1; }
+
+          # Read the output path out of the tape rather than assuming it. The PR
+          # step needs the exact path: create-pull-request only stages what
+          # add-paths names, so a hard-coded path silently drops the new GIF and
+          # reports "no changes" while the render itself succeeded.
+          GIF=$(awk '/^Output[[:space:]]+/{print $2; exit}' "$TAPE")
+          test -n "$GIF" || { echo "::error::no Output line in $TAPE"; exit 1; }
+
           vhs "$TAPE"
+
+          test -s "$GIF" || { echo "::error::render produced no file at $GIF"; exit 1; }
+          echo "gif=$GIF" >> "$GITHUB_OUTPUT"
+          echo "Rendered $GIF ($(du -h "$GIF" | cut -f1))"
 
       - name: Open PR with the regenerated GIF
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
-          branch: chore/demo-gif-render
+          branch: chore/demo-gif-render-${{ hashFiles(inputs.tape || 'docs/demo/aigis-demo.tape') }}
           title: "docs: regenerate aigis demo GIF (VHS)"
           commit-message: "docs: regenerate aigis demo GIF via VHS"
           body: |
@@ -72,7 +85,7 @@ jobs:
             Once merged, embed it with:
 
             ```html
-            <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-demo.gif" width="760" />
+            <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/${{ steps.render.outputs.gif }}" width="760" />
             ```
-          add-paths: docs/demo/aigis-demo.gif
+          add-paths: ${{ steps.render.outputs.gif }}
           signoff: true


### PR DESCRIPTION
## What happened

Run [32698183290](https://github.com/killertcell428/aigis/actions/runs/32698183290) rendered `docs/demo/aigis-profile.tape`, every step went green — and no GIF appeared. No PR, no branch, nothing on master.

#252 added the `tape` input but left three fields pointing at the v1.2 GIF. The one that mattered:

```yaml
add-paths: docs/demo/aigis-demo.gif
```

`create-pull-request` only stages what `add-paths` names. The render wrote `docs/demo/aigis-profile.gif`, that file was never staged, and the action then correctly reported no changes. **A success with nothing to show for it** — the failure mode where nothing errors and the result is simply absent.

## The fix

Read the output path out of the tape instead of assuming it:

```bash
GIF=$(awk '/^Output[[:space:]]+/{print $2; exit}' "$TAPE")
```

`add-paths`, the embed snippet in the PR body, and the PR branch name now all derive from that. Verified against both tapes before committing:

```
docs/demo/aigis-demo.tape      -> docs/demo/aigis-demo.gif
docs/demo/aigis-profile.tape   -> docs/demo/aigis-profile.gif
```

## Two guards, so this cannot go quiet again

- **Fail if the tape has no `Output` line.** An empty path passed to `add-paths` reads as "stage nothing", which is exactly the silent no-op above.
- **Fail if the render leaves no file at that path.** Then `vhs` exiting 0 without producing output is caught in the render step, rather than surfacing later as an empty PR.

Both are the same principle: make the absence of a result an error, not a pass.

## Also

The PR branch name now includes a hash of the tape path. Two tapes sharing `chore/demo-gif-render` would overwrite each other's pending PR.

## After merging

```bash
gh workflow run demo-gif.yml -f tape=docs/demo/aigis-profile.tape
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
