### PR TITLE
docs: add v2.0 demo GIF section to README (EN/JA)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -121,6 +121,22 @@ curl -X POST http://localhost:8080/v1/check/input \
 
 ---
 
+## v2.0 の新機能：1つのファイルから2つの防御層を生成する
+
+v2.0 は検出パターン数の競争から降り、セキュリティレビューが本当に聞きたい問い ―― *誰に何を許すか*　―― に答えるようになりました。`aigis profile` は6つの capability（web / files / shell / git / packages / mcp）から役割を組み立て、**Aigis のポリシーと Claude Code 自身の権限設定の両方**を1つのファイルから導出します。2つの層が別々に手で書かれることがないため、ズレが生じません。
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-profile.gif" alt="Aigis v2.0 デモ：6つの capability から役割を組み立て、2つの防御層を生成する" width="760" />
+</p>
+
+1. **`aigis profile show`** — その役割にできること／できないことを、ルール構文ではなく承認者が読める言葉で表示
+2. **`aigis profile build`** — 1つのファイルを入力に、`aigis-policy.yaml`（フック側）と `.claude/settings.json`（Claude Code 自身の権限設定）という2つの防御層を出力
+3. Claude Code 側の設定 —— フックより先に評価される外側の門 —— を手書きではなく生成する
+
+スタータープロファイルは [`profiles/`](profiles/) を、破壊的変更の全リスト（`--policy` 廃止、`[server]` extra 廃止、未リリースだった3サブシステムの削除）は [v2.0.1 リリースノート](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) を参照してください。
+
+---
+
 ## v1.2 の新機能：見えない ANSI 攻撃を検知し、IT 承認パックを生成する
 
 v1.2 では **ANSI エスケープに隠した命令**（目に見えないターミナル制御コードに埋め込まれた攻撃）の検出と、`aigis trust-pack` / `aigis audit` コマンドを追加しました。下のクリップは、実際のコマンドを4つ通しで実行しています。

--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ Endpoints: `POST /v1/check/input` · `POST /v1/check/output` · `POST /v1/check/
 
 ---
 
+## New in v2.0: one file, two enforcement layers
+
+v2.0 stops competing on detection-pattern count and answers the question a security review actually asks: *who is allowed to do what.* `aigis profile` composes a role from six capabilities (web/files/shell/git/packages/mcp) and derives **both** the Aigis policy and Claude Code's own permission settings from that single file, so the two layers can't drift apart.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-profile.gif" alt="Aigis v2.0 demo: composing a role from six capabilities and generating both enforcement layers" width="760" />
+</p>
+
+1. **`aigis profile show`** — what the role can and cannot do, stated in plain language for whoever approves it, not in rule syntax.
+2. **`aigis profile build`** — one file in, two enforcement layers out: `aigis-policy.yaml` (the hook) and `.claude/settings.json` (Claude Code's own rules).
+3. The Claude Code side — the outer gate Claude Code checks *before* any hook runs — generated instead of hand-written.
+
+See [`profiles/`](profiles/) for starter profiles and the [v2.0.1 release notes](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) for the full breaking-change list (`--policy` removed, the `[server]` extra removed, three unreleased subsystems dropped).
+
+---
+
 ## New in v1.2: catch invisible-ANSI attacks, then generate an IT-approval pack
 
 v1.2 adds detection for **ANSI-concealed instructions** (payloads hidden inside invisible terminal escape codes), plus the `aigis trust-pack` and `aigis audit` commands. The clip below runs four real commands end to end:


### PR DESCRIPTION
## Summary
- Adds a "New in v2.0" section to README.md / README.ja.md, mirroring the existing v1.2 section's format
- Embeds `docs/demo/aigis-profile.gif` (merged via #254) showing `aigis profile show` / `aigis profile build` and the generated `.claude/settings.json`
- Links to the v2.0.1 release notes for the full breaking-change list

## Test plan
- [x] GIF URL matches the path merged in #254 (`docs/demo/aigis-profile.gif` on master)
- [x] EN/JA sections parallel in structure and content