### PR TITLE
ci: bump twine 6.2.0 -> 7.0.0 for Core-Metadata 2.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install build
-        run: uv pip install --system 'build==1.5.0' 'twine==6.2.0'
+        run: uv pip install --system 'build==1.5.0' 'twine==7.0.0'
 
       - name: Build wheel and sdist
         run: python -m build


### PR DESCRIPTION
## Summary
- hatchling 1.32+ emits Core-Metadata 2.5 in wheel metadata
- twine 6.2.0 rejects it with `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`
- This is [pypa/twine#1327](https://github.com/pypa/twine/issues/1327), fixed in twine 7.0.0 (2026-07-27)
- Currently blocks dependabot PR #241 (hatchling requirement bump) from passing `Build package`

## Test plan
- [x] CI's own `Build package` job runs `twine check dist/*` against this repo's build — passing here confirms compatibility