### PR TITLE
ci(demo-gif): move write permissions from workflow to job level

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -18,12 +18,14 @@ on:
           - docs/demo/aigis-profile.tape
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   render:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # commit the rendered GIF
+      pull-requests: write   # open the PR with it
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4


### PR DESCRIPTION
## Summary
- Fixes Scorecard Token-Permissions alert [#203](https://github.com/killertcell428/aigis/security/code-scanning/203): `contents: write` / `pull-requests: write` were declared at the workflow (top) level
- Moves them to the `render` job, matching the pattern already used in ci.yml, release.yml, paper-review.yml, sync-zenn-qiita.yml, zenn-deploy-trigger.yml
- No behavior change: this workflow has a single job, so the effective grant is identical

## Test plan
- [x] Required checks pass (this PR doesn't touch anything the render job runs)