### PR TITLE
docs(readme): rewrite the v2.0 section around what the user gains

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -92,7 +92,7 @@ aigis init --agent claude-code
 
 `--signed-audit` を付けると、改ざん検知つき監査ログも同時に初期化します。
 
-部署ごとにルールを変えたい場合は [`profiles/`](profiles/) を参照してください。`aigis profile build` は6つの capability で書いた役割定義ファイル1つから、Aigis のポリシーと Claude Code 自身の権限設定の両方を生成します。（`--policy` フラグは v2.0 で削除しました。4つの値はポリシーの名前を変えるだけだったためです。）
+部署ごとに権限を変えたい場合は [`profiles/`](profiles/) を参照してください。役割ごとに6項目を選べば、`aigis profile build` が設定ファイル2つ（Aigis のポリシーと Claude Code 自身の権限設定）を書いてくれます。（`--policy` フラグは v2.0 で削除しました。4つの値はポリシーの名前を変えるだけだったためです。）
 </details>
 
 <details>
@@ -121,19 +121,24 @@ curl -X POST http://localhost:8080/v1/check/input \
 
 ---
 
-## v2.0 の新機能：役割定義1ファイルから、権限設定を2つ生成する
+## v2.0 の新機能：部署ごとに違う権限を、設定ファイルを手で書かずに用意する
 
-`aigis profile build` は、web / files / shell / git / packages / mcp の6つの capability で書いた役割定義ファイル1つから、Aigis 自身のポリシー（`aigis-policy.yaml`）と Claude Code の権限設定（`.claude/settings.json`）を両方生成します。これまではこの2つを別々に手で書いていたため食い違うことがありましたが、同じ元ファイルから両方を生成することでその心配がなくなりました。
+Claude Code を複数の部署に展開すると、部署ごとに許す範囲が変わります。マーケティング部に `npm install` は要らないが、開発部には要る。これを実現するには、これまで部署ごとに2つの設定ファイルを手で書く必要がありました。Claude Code 自身の権限ルールと、Aigis のフックが参照するポリシーです。
+
+`aigis profile build` は、これを6項目の選択に置き換えます。[`profiles/`](profiles/) 同梱のマーケティング用の役割定義は15行で、そこから2つの設定ファイルに合計56ルールが書き出されます。
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-profile.gif" alt="Aigis v2.0 デモ：aigis profile show と aigis profile build が役割定義ファイル1つから2つの権限設定を生成する" width="760" />
 </p>
 
-1. `aigis profile show` — その役割にできること・できないことを、ルール構文ではなく承認者が読める言葉で表示する
-2. `aigis profile build` — 役割定義ファイル1つから `aigis-policy.yaml`（フック側のルール）と `.claude/settings.json`（Claude Code 自身のルール）を生成する
-3. Claude Code は自身の設定を、Aigis のフックより先に評価するため、この設定ファイルも手書きではなく生成する対象にした
+- **手で書くルールがゼロになる。** `web: read` `files: workspace` `shell: none` `git: none` `packages: none` `mcp: approved` の6項目から、191行の Aigis ポリシー（30ルール）と Claude Code の権限ルール26件が生成されます。
+- **正確に変換できないルールは、近似せず報告される。** 2つの書式はワイルドカードの意味が違います。Aigis は fnmatch で `*` がディレクトリを跨ぎますが、Claude Code は `Bash()` をコマンド先頭で一致させ、パスには gitignore 形式を使います。30ルールのうち10件は Claude Code の書式では正確に表現できないため、同等に見えて実際は緩いルールを書くのではなく、1件ずつ理由と手書きの代替案を提示します。
+- **承認する人が読める形式で出る。** `aigis profile show` は「シェルコマンドを実行できない」「依存パッケージをインストールできない」のような平文で表示します。部門長が承認印を押せるのはこちらで、191行の YAML ではありません。
+- **情シスが中央で強制できる形式も出せる。** `--managed` を付けると `managed-settings.json` 形式で出力します。この層は他のどの設定レベルからも上書きできません。コマンドライン引数でも上書きできません。
 
-スタータープロファイルは [`profiles/`](profiles/) を、破壊的変更の全リスト（`--policy` 廃止、`[server]` extra 廃止、未リリースだった3サブシステムの削除）は [v2.0.1 リリースノート](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) を参照してください。
+Claude Code は自身の権限ルールをフックより先に評価します。だからこの設定ファイルは、手で保守するのではなく生成する価値があります。
+
+[`profiles/`](profiles/) の3つの役割定義は出発点であって答えではありません。「マーケティング部とは何か」についての前提が入っており、それはおそらく自社には合いません。コピーして書き換えて使ってください。破壊的変更の全リスト（`--policy` 廃止、`[server]` extra 廃止、未リリースだった3サブシステムの削除）は [v2.0.1 リリースノート](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) を参照してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ aigis init --agent claude-code
 
 Add `--signed-audit` to initialise the tamper-evident log at the same time.
 
-For rules that differ by department, see [`profiles/`](profiles/): `aigis profile build` takes one role file, written as six capabilities, and writes both the Aigis policy and Claude Code's own permission settings from it. (The `--policy` flag was removed in v2.0 — its four values only changed the policy's name.)
+To give different teams different permissions, see [`profiles/`](profiles/): pick six values for a role and `aigis profile build` writes both config files for you — the Aigis policy and Claude Code's own permission settings. (The `--policy` flag was removed in v2.0 — its four values only changed the policy's name.)
 </details>
 
 <details>
@@ -119,19 +119,24 @@ Endpoints: `POST /v1/check/input` · `POST /v1/check/output` · `POST /v1/check/
 
 ---
 
-## New in v2.0: one role file, two generated permission files
+## New in v2.0: give each team its own permissions without writing config by hand
 
-`aigis profile build` reads one role definition — six settings covering web, files, shell, git, packages, and MCP access — and writes both Aigis's own policy (`aigis-policy.yaml`) and Claude Code's permission settings (`.claude/settings.json`) from it. Previously these were two files you maintained by hand, which meant they could drift out of sync; generating both from the same source removes that risk.
+Rolling Claude Code out past one team means different permissions per team — marketing doesn't need `npm install`, engineering does. Setting that up used to mean hand-writing two config files per team: Claude Code's own permission rules, and the policy the Aigis hook enforces.
+
+`aigis profile build` replaces that with six choices. For the marketing role in [`profiles/`](profiles/), a 15-line file produces 56 rules across both config files:
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/killertcell428/aigis/master/docs/demo/aigis-profile.gif" alt="Aigis v2.0 demo: aigis profile show and aigis profile build generating both permission files from one role file" width="760" />
 </p>
 
-1. `aigis profile show` — what the role can and cannot do, in plain language, for whoever has to approve it.
-2. `aigis profile build` — writes `aigis-policy.yaml` (the hook's rules) and `.claude/settings.json` (Claude Code's own rules) from the one role file.
-3. Claude Code checks its own settings before any Aigis hook runs, so that file is generated here rather than hand-written.
+- **No rules to write by hand.** `web: read`, `files: workspace`, `shell: none`, `git: none`, `packages: none`, `mcp: approved` becomes a 191-line Aigis policy (30 rules) and 26 Claude Code permission rules.
+- **Rules that can't be translated are reported, not approximated.** The two formats disagree on what a wildcard means: Aigis matches with fnmatch, where `*` crosses directories, while Claude Code anchors `Bash()` at the start of the command and uses gitignore syntax for paths. 10 of the 30 policy rules can't be expressed exactly in Claude Code's format, so each one is listed with the reason and a hand-written alternative rather than emitted as something looser that looks equivalent.
+- **Something your approver can read.** `aigis profile show` prints the role as plain sentences ("Cannot run shell commands", "Cannot install dependencies"). That's what a department head signs off on; 191 lines of YAML is not.
+- **A form IT can enforce centrally.** `--managed` emits the `managed-settings.json` variant, which no other settings level can override — not even command line arguments.
 
-See [`profiles/`](profiles/) for starter role files, and the [v2.0.1 release notes](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) for the full breaking-change list (`--policy` removed, the `[server]` extra removed, three unreleased subsystems dropped).
+Claude Code checks its own permission rules before any hook runs, which is why that file is worth generating rather than leaving to hand-maintenance.
+
+The three roles in [`profiles/`](profiles/) are starting points, not answers — they encode assumptions about what "marketing" means that are probably wrong for your company. Copy one and edit it. See the [v2.0.1 release notes](https://github.com/killertcell428/aigis/releases/tag/v2.0.1) for the full breaking-change list (`--policy` removed, the `[server]` extra removed, three unreleased subsystems dropped).
 
 ---
 


### PR DESCRIPTION
## Why

The previous heading — "one role file, two generated permission files" — described the mechanism, not the benefit. It invited exactly the questions it should have answered: *so what if two files got generated? Is the count the point? Did permission settings not exist before?*

## What changed

Leads with the outcome instead: **give each team its own permissions without writing config by hand.** Then answers the "why is that good" with numbers measured from an actual run of `aigis profile build profiles/marketing.json`:

| | |
|---|---|
| input | `profiles/marketing.json` — 15 lines, 6 choices |
| output | `aigis-policy.yaml` — 191 lines, 30 rules |
| output | `.claude/settings.json` — 26 permission rules |
| reported | 10 of the 30 rules that can't be expressed in Claude Code's syntax |

Four things the reader gets, each concrete:

1. No rules to write by hand (6 choices → 56 rules)
2. Rules that can't be translated exactly are reported with a reason, not approximated into something looser
3. `aigis profile show` output is readable by the person who approves it, unlike 191 lines of YAML
4. `--managed` produces the `managed-settings.json` form that no other settings level can override

Also states plainly why there are two layers at all — Claude Code evaluates its own permission rules before any hook runs — since "why 2" was the unanswered question in the old text.

## Verification

Numbers came from running the command, not from the docs:

```
$ aigis profile build profiles/marketing.json
  Wrote aigis-policy.yaml (30 rules)
  Wrote .claude/settings.json (26 permission rules)
  10 policy rule(s) could not be expressed as Claude Code permissions...
```

## Test plan
- [x] Every number in the section verified against actual command output
- [x] `--managed` flag confirmed present on `profile build` (aigis/cli.py:330)
- [x] Docs-only change